### PR TITLE
Refactor API Functions, Introduce Price Collector, and Update Swagger Documentation

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -888,6 +888,80 @@ const docTemplate = `{
             }
         },
         "/api/v1/price/info": {
+            "get": {
+                "description": "Retrieve pricing information for cloud resources based on specified query parameters. Returns price data based on provider, region, instance type, vCPU, memory, and OS type. It offer instances with the lowest monthly prices what in the database.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Price Management"
+                ],
+                "summary": "Get Price Information",
+                "operationId": "GetPriceInfos",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cloud provider name - aws|alibaba|tencent|gcp|azure|ibm",
+                        "name": "providerName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Region name",
+                        "name": "regionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance type",
+                        "name": "instanceType",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Number of vCPUs",
+                        "name": "vCpu",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount of memory",
+                        "name": "memory",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operating system type",
+                        "name": "osType",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved pricing information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to retrieve pricing information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Retrieve pricing information for cloud resources based on specified parameters. If saved data is more than 7 days, fetch new data and insert new price data even if same price as before.",
                 "consumes": [
@@ -899,8 +973,7 @@ const docTemplate = `{
                 "tags": [
                     "[Price Management]"
                 ],
-                "summary": "Get Price Information",
-                "operationId": "GetPriceInfo",
+                "operationId": "UpdatePriceInfos",
                 "parameters": [
                     {
                         "description": "Request body containing get price information",
@@ -908,7 +981,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/app.GetPriceInfoReq"
+                            "$ref": "#/definitions/app.UpdatePriceInfosReq"
                         }
                     }
                 ],
@@ -916,7 +989,7 @@ const docTemplate = `{
                     "200": {
                         "description": "Successfully retrieved pricing information",
                         "schema": {
-                            "$ref": "#/definitions/app.AntResponse-cost_AllPriceInfoResult"
+                            "$ref": "#/definitions/app.AntResponse-string"
                         }
                     },
                     "400": {
@@ -1010,23 +1083,6 @@ const docTemplate = `{
                     "items": {
                         "$ref": "#/definitions/load.ResultSummary"
                     }
-                },
-                "successMessage": {
-                    "type": "string"
-                }
-            }
-        },
-        "app.AntResponse-cost_AllPriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer"
-                },
-                "errorMessage": {
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/definitions/cost.AllPriceInfoResult"
                 },
                 "successMessage": {
                     "type": "string"
@@ -1248,40 +1304,6 @@ const docTemplate = `{
                 }
             }
         },
-        "app.GetPriceInfoReq": {
-            "type": "object",
-            "required": [
-                "instanceType",
-                "providerName",
-                "regionName"
-            ],
-            "properties": {
-                "instanceType": {
-                    "type": "string"
-                },
-                "memory": {
-                    "type": "string"
-                },
-                "osType": {
-                    "type": "string"
-                },
-                "providerName": {
-                    "type": "string"
-                },
-                "regionName": {
-                    "type": "string"
-                },
-                "storage": {
-                    "type": "string"
-                },
-                "vCpu": {
-                    "type": "string"
-                },
-                "zoneName": {
-                    "type": "string"
-                }
-            }
-        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1409,6 +1431,25 @@ const docTemplate = `{
                 }
             }
         },
+        "app.UpdatePriceInfosReq": {
+            "type": "object",
+            "required": [
+                "instanceType",
+                "providerName",
+                "regionName"
+            ],
+            "properties": {
+                "instanceType": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
         "constant.ExecutionStatus": {
             "type": "string",
             "enum": [
@@ -1449,37 +1490,6 @@ const docTemplate = `{
                 "Remote"
             ]
         },
-        "constant.PriceCurrency": {
-            "type": "string",
-            "enum": [
-                "USD",
-                "KRW"
-            ],
-            "x-enum-varnames": [
-                "USD",
-                "KRW"
-            ]
-        },
-        "constant.PricePolicy": {
-            "type": "string",
-            "enum": [
-                "OnDemand"
-            ],
-            "x-enum-varnames": [
-                "OnDemand"
-            ]
-        },
-        "constant.PriceUnit": {
-            "type": "string",
-            "enum": [
-                "PerHour",
-                "PerYear"
-            ],
-            "x-enum-varnames": [
-                "PerHour",
-                "PerYear"
-            ]
-        },
         "constant.ResourceType": {
             "type": "string",
             "enum": [
@@ -1494,23 +1504,6 @@ const docTemplate = `{
                 "DataDisk",
                 "Etc"
             ]
-        },
-        "cost.AllPriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "infoSource": {
-                    "type": "string"
-                },
-                "priceInfoList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cost.PriceInfoResult"
-                    }
-                },
-                "resultCount": {
-                    "type": "integer"
-                }
-            }
         },
         "cost.GetCostInfoResult": {
             "type": "object",
@@ -1534,65 +1527,6 @@ const docTemplate = `{
                     "type": "number"
                 },
                 "unit": {
-                    "type": "string"
-                }
-            }
-        },
-        "cost.PriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "calculatedMonthlyPrice": {
-                    "type": "string"
-                },
-                "currency": {
-                    "$ref": "#/definitions/constant.PriceCurrency"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "instanceType": {
-                    "type": "string"
-                },
-                "lastUpdatedAt": {
-                    "type": "string"
-                },
-                "memory": {
-                    "type": "string"
-                },
-                "originalPricePolicy": {
-                    "type": "string"
-                },
-                "osType": {
-                    "type": "string"
-                },
-                "price": {
-                    "type": "string"
-                },
-                "priceDescription": {
-                    "type": "string"
-                },
-                "pricePolicy": {
-                    "$ref": "#/definitions/constant.PricePolicy"
-                },
-                "productDescription": {
-                    "type": "string"
-                },
-                "providerName": {
-                    "type": "string"
-                },
-                "regionName": {
-                    "type": "string"
-                },
-                "storage": {
-                    "type": "string"
-                },
-                "unit": {
-                    "$ref": "#/definitions/constant.PriceUnit"
-                },
-                "vCpu": {
-                    "type": "string"
-                },
-                "zoneName": {
                     "type": "string"
                 }
             }

--- a/api/docs.go
+++ b/api/docs.go
@@ -888,8 +888,8 @@ const docTemplate = `{
             }
         },
         "/api/v1/price/info": {
-            "get": {
-                "description": "Retrieve pricing information for cloud resources based on specified parameters.",
+            "post": {
+                "description": "Retrieve pricing information for cloud resources based on specified parameters. If saved data is more than 7 days, fetch new data and insert new price data even if same price as before.",
                 "consumes": [
                     "application/json"
                 ],
@@ -903,62 +903,13 @@ const docTemplate = `{
                 "operationId": "GetPriceInfo",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Name of the region",
-                        "name": "regionName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the connection",
-                        "name": "connectionName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the cloud provider",
-                        "name": "providerName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Type of the instance",
-                        "name": "instanceType",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the zone",
-                        "name": "zoneName",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Number of virtual CPUs",
-                        "name": "vCpu",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Amount of memory. Don't need to pass unit like 'gb'",
-                        "name": "memory",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Amount of storage",
-                        "name": "storage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Operating system type",
-                        "name": "osType",
-                        "in": "query"
+                        "description": "Request body containing get price information",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.GetPriceInfoReq"
+                        }
                     }
                 ],
                 "responses": {
@@ -1297,6 +1248,40 @@ const docTemplate = `{
                 }
             }
         },
+        "app.GetPriceInfoReq": {
+            "type": "object",
+            "required": [
+                "instanceType",
+                "providerName",
+                "regionName"
+            ],
+            "properties": {
+                "instanceType": {
+                    "type": "string"
+                },
+                "memory": {
+                    "type": "string"
+                },
+                "osType": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                },
+                "storage": {
+                    "type": "string"
+                },
+                "vCpu": {
+                    "type": "string"
+                },
+                "zoneName": {
+                    "type": "string"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1559,9 +1544,6 @@ const docTemplate = `{
                 "calculatedMonthlyPrice": {
                     "type": "string"
                 },
-                "connectionName": {
-                    "type": "string"
-                },
                 "currency": {
                     "$ref": "#/definitions/constant.PriceCurrency"
                 },
@@ -1575,6 +1557,9 @@ const docTemplate = `{
                     "type": "string"
                 },
                 "memory": {
+                    "type": "string"
+                },
+                "originalPricePolicy": {
                     "type": "string"
                 },
                 "osType": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -880,8 +880,8 @@
             }
         },
         "/api/v1/price/info": {
-            "get": {
-                "description": "Retrieve pricing information for cloud resources based on specified parameters.",
+            "post": {
+                "description": "Retrieve pricing information for cloud resources based on specified parameters. If saved data is more than 7 days, fetch new data and insert new price data even if same price as before.",
                 "consumes": [
                     "application/json"
                 ],
@@ -895,62 +895,13 @@
                 "operationId": "GetPriceInfo",
                 "parameters": [
                     {
-                        "type": "string",
-                        "description": "Name of the region",
-                        "name": "regionName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the connection",
-                        "name": "connectionName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the cloud provider",
-                        "name": "providerName",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Type of the instance",
-                        "name": "instanceType",
-                        "in": "query",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Name of the zone",
-                        "name": "zoneName",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Number of virtual CPUs",
-                        "name": "vCpu",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Amount of memory. Don't need to pass unit like 'gb'",
-                        "name": "memory",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Amount of storage",
-                        "name": "storage",
-                        "in": "query"
-                    },
-                    {
-                        "type": "string",
-                        "description": "Operating system type",
-                        "name": "osType",
-                        "in": "query"
+                        "description": "Request body containing get price information",
+                        "name": "body",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/app.GetPriceInfoReq"
+                        }
                     }
                 ],
                 "responses": {
@@ -1289,6 +1240,40 @@
                 }
             }
         },
+        "app.GetPriceInfoReq": {
+            "type": "object",
+            "required": [
+                "instanceType",
+                "providerName",
+                "regionName"
+            ],
+            "properties": {
+                "instanceType": {
+                    "type": "string"
+                },
+                "memory": {
+                    "type": "string"
+                },
+                "osType": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                },
+                "storage": {
+                    "type": "string"
+                },
+                "vCpu": {
+                    "type": "string"
+                },
+                "zoneName": {
+                    "type": "string"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1551,9 +1536,6 @@
                 "calculatedMonthlyPrice": {
                     "type": "string"
                 },
-                "connectionName": {
-                    "type": "string"
-                },
                 "currency": {
                     "$ref": "#/definitions/constant.PriceCurrency"
                 },
@@ -1567,6 +1549,9 @@
                     "type": "string"
                 },
                 "memory": {
+                    "type": "string"
+                },
+                "originalPricePolicy": {
                     "type": "string"
                 },
                 "osType": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -880,6 +880,80 @@
             }
         },
         "/api/v1/price/info": {
+            "get": {
+                "description": "Retrieve pricing information for cloud resources based on specified query parameters. Returns price data based on provider, region, instance type, vCPU, memory, and OS type. It offer instances with the lowest monthly prices what in the database.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Price Management"
+                ],
+                "summary": "Get Price Information",
+                "operationId": "GetPriceInfos",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Cloud provider name - aws|alibaba|tencent|gcp|azure|ibm",
+                        "name": "providerName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Region name",
+                        "name": "regionName",
+                        "in": "query",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance type",
+                        "name": "instanceType",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Number of vCPUs",
+                        "name": "vCpu",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Amount of memory",
+                        "name": "memory",
+                        "in": "query"
+                    },
+                    {
+                        "type": "string",
+                        "description": "Operating system type",
+                        "name": "osType",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Successfully retrieved pricing information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    },
+                    "500": {
+                        "description": "Failed to retrieve pricing information",
+                        "schema": {
+                            "$ref": "#/definitions/app.AntResponse-string"
+                        }
+                    }
+                }
+            },
             "post": {
                 "description": "Retrieve pricing information for cloud resources based on specified parameters. If saved data is more than 7 days, fetch new data and insert new price data even if same price as before.",
                 "consumes": [
@@ -891,8 +965,7 @@
                 "tags": [
                     "[Price Management]"
                 ],
-                "summary": "Get Price Information",
-                "operationId": "GetPriceInfo",
+                "operationId": "UpdatePriceInfos",
                 "parameters": [
                     {
                         "description": "Request body containing get price information",
@@ -900,7 +973,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/app.GetPriceInfoReq"
+                            "$ref": "#/definitions/app.UpdatePriceInfosReq"
                         }
                     }
                 ],
@@ -908,7 +981,7 @@
                     "200": {
                         "description": "Successfully retrieved pricing information",
                         "schema": {
-                            "$ref": "#/definitions/app.AntResponse-cost_AllPriceInfoResult"
+                            "$ref": "#/definitions/app.AntResponse-string"
                         }
                     },
                     "400": {
@@ -1002,23 +1075,6 @@
                     "items": {
                         "$ref": "#/definitions/load.ResultSummary"
                     }
-                },
-                "successMessage": {
-                    "type": "string"
-                }
-            }
-        },
-        "app.AntResponse-cost_AllPriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "code": {
-                    "type": "integer"
-                },
-                "errorMessage": {
-                    "type": "string"
-                },
-                "result": {
-                    "$ref": "#/definitions/cost.AllPriceInfoResult"
                 },
                 "successMessage": {
                     "type": "string"
@@ -1240,40 +1296,6 @@
                 }
             }
         },
-        "app.GetPriceInfoReq": {
-            "type": "object",
-            "required": [
-                "instanceType",
-                "providerName",
-                "regionName"
-            ],
-            "properties": {
-                "instanceType": {
-                    "type": "string"
-                },
-                "memory": {
-                    "type": "string"
-                },
-                "osType": {
-                    "type": "string"
-                },
-                "providerName": {
-                    "type": "string"
-                },
-                "regionName": {
-                    "type": "string"
-                },
-                "storage": {
-                    "type": "string"
-                },
-                "vCpu": {
-                    "type": "string"
-                },
-                "zoneName": {
-                    "type": "string"
-                }
-            }
-        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -1401,6 +1423,25 @@
                 }
             }
         },
+        "app.UpdatePriceInfosReq": {
+            "type": "object",
+            "required": [
+                "instanceType",
+                "providerName",
+                "regionName"
+            ],
+            "properties": {
+                "instanceType": {
+                    "type": "string"
+                },
+                "providerName": {
+                    "type": "string"
+                },
+                "regionName": {
+                    "type": "string"
+                }
+            }
+        },
         "constant.ExecutionStatus": {
             "type": "string",
             "enum": [
@@ -1441,37 +1482,6 @@
                 "Remote"
             ]
         },
-        "constant.PriceCurrency": {
-            "type": "string",
-            "enum": [
-                "USD",
-                "KRW"
-            ],
-            "x-enum-varnames": [
-                "USD",
-                "KRW"
-            ]
-        },
-        "constant.PricePolicy": {
-            "type": "string",
-            "enum": [
-                "OnDemand"
-            ],
-            "x-enum-varnames": [
-                "OnDemand"
-            ]
-        },
-        "constant.PriceUnit": {
-            "type": "string",
-            "enum": [
-                "PerHour",
-                "PerYear"
-            ],
-            "x-enum-varnames": [
-                "PerHour",
-                "PerYear"
-            ]
-        },
         "constant.ResourceType": {
             "type": "string",
             "enum": [
@@ -1486,23 +1496,6 @@
                 "DataDisk",
                 "Etc"
             ]
-        },
-        "cost.AllPriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "infoSource": {
-                    "type": "string"
-                },
-                "priceInfoList": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cost.PriceInfoResult"
-                    }
-                },
-                "resultCount": {
-                    "type": "integer"
-                }
-            }
         },
         "cost.GetCostInfoResult": {
             "type": "object",
@@ -1526,65 +1519,6 @@
                     "type": "number"
                 },
                 "unit": {
-                    "type": "string"
-                }
-            }
-        },
-        "cost.PriceInfoResult": {
-            "type": "object",
-            "properties": {
-                "calculatedMonthlyPrice": {
-                    "type": "string"
-                },
-                "currency": {
-                    "$ref": "#/definitions/constant.PriceCurrency"
-                },
-                "id": {
-                    "type": "integer"
-                },
-                "instanceType": {
-                    "type": "string"
-                },
-                "lastUpdatedAt": {
-                    "type": "string"
-                },
-                "memory": {
-                    "type": "string"
-                },
-                "originalPricePolicy": {
-                    "type": "string"
-                },
-                "osType": {
-                    "type": "string"
-                },
-                "price": {
-                    "type": "string"
-                },
-                "priceDescription": {
-                    "type": "string"
-                },
-                "pricePolicy": {
-                    "$ref": "#/definitions/constant.PricePolicy"
-                },
-                "productDescription": {
-                    "type": "string"
-                },
-                "providerName": {
-                    "type": "string"
-                },
-                "regionName": {
-                    "type": "string"
-                },
-                "storage": {
-                    "type": "string"
-                },
-                "unit": {
-                    "$ref": "#/definitions/constant.PriceUnit"
-                },
-                "vCpu": {
-                    "type": "string"
-                },
-                "zoneName": {
                     "type": "string"
                 }
             }

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -202,6 +202,29 @@ definitions:
       resourceType:
         $ref: '#/definitions/constant.ResourceType'
     type: object
+  app.GetPriceInfoReq:
+    properties:
+      instanceType:
+        type: string
+      memory:
+        type: string
+      osType:
+        type: string
+      providerName:
+        type: string
+      regionName:
+        type: string
+      storage:
+        type: string
+      vCpu:
+        type: string
+      zoneName:
+        type: string
+    required:
+    - instanceType
+    - providerName
+    - regionName
+    type: object
   app.InstallLoadGeneratorReq:
     properties:
       installLocation:
@@ -385,8 +408,6 @@ definitions:
     properties:
       calculatedMonthlyPrice:
         type: string
-      connectionName:
-        type: string
       currency:
         $ref: '#/definitions/constant.PriceCurrency'
       id:
@@ -396,6 +417,8 @@ definitions:
       lastUpdatedAt:
         type: string
       memory:
+        type: string
+      originalPricePolicy:
         type: string
       osType:
         type: string
@@ -1321,53 +1344,20 @@ paths:
       tags:
       - '[Load Test Execution Management]'
   /api/v1/price/info:
-    get:
+    post:
       consumes:
       - application/json
       description: Retrieve pricing information for cloud resources based on specified
-        parameters.
+        parameters. If saved data is more than 7 days, fetch new data and insert new
+        price data even if same price as before.
       operationId: GetPriceInfo
       parameters:
-      - description: Name of the region
-        in: query
-        name: regionName
+      - description: Request body containing get price information
+        in: body
+        name: body
         required: true
-        type: string
-      - description: Name of the connection
-        in: query
-        name: connectionName
-        required: true
-        type: string
-      - description: Name of the cloud provider
-        in: query
-        name: providerName
-        required: true
-        type: string
-      - description: Type of the instance
-        in: query
-        name: instanceType
-        required: true
-        type: string
-      - description: Name of the zone
-        in: query
-        name: zoneName
-        type: string
-      - description: Number of virtual CPUs
-        in: query
-        name: vCpu
-        type: string
-      - description: Amount of memory. Don't need to pass unit like 'gb'
-        in: query
-        name: memory
-        type: string
-      - description: Amount of storage
-        in: query
-        name: storage
-        type: string
-      - description: Operating system type
-        in: query
-        name: osType
-        type: string
+        schema:
+          $ref: '#/definitions/app.GetPriceInfoReq'
       produces:
       - application/json
       responses:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -52,17 +52,6 @@ definitions:
       successMessage:
         type: string
     type: object
-  app.AntResponse-cost_AllPriceInfoResult:
-    properties:
-      code:
-        type: integer
-      errorMessage:
-        type: string
-      result:
-        $ref: '#/definitions/cost.AllPriceInfoResult'
-      successMessage:
-        type: string
-    type: object
   app.AntResponse-cost_UpdateCostInfoResult:
     properties:
       code:
@@ -202,29 +191,6 @@ definitions:
       resourceType:
         $ref: '#/definitions/constant.ResourceType'
     type: object
-  app.GetPriceInfoReq:
-    properties:
-      instanceType:
-        type: string
-      memory:
-        type: string
-      osType:
-        type: string
-      providerName:
-        type: string
-      regionName:
-        type: string
-      storage:
-        type: string
-      vCpu:
-        type: string
-      zoneName:
-        type: string
-    required:
-    - instanceType
-    - providerName
-    - regionName
-    type: object
   app.InstallLoadGeneratorReq:
     properties:
       installLocation:
@@ -308,6 +274,19 @@ definitions:
     - connectionName
     - costResources
     type: object
+  app.UpdatePriceInfosReq:
+    properties:
+      instanceType:
+        type: string
+      providerName:
+        type: string
+      regionName:
+        type: string
+    required:
+    - instanceType
+    - providerName
+    - regionName
+    type: object
   constant.ExecutionStatus:
     enum:
     - on_preparing
@@ -342,28 +321,6 @@ definitions:
     x-enum-varnames:
     - Local
     - Remote
-  constant.PriceCurrency:
-    enum:
-    - USD
-    - KRW
-    type: string
-    x-enum-varnames:
-    - USD
-    - KRW
-  constant.PricePolicy:
-    enum:
-    - OnDemand
-    type: string
-    x-enum-varnames:
-    - OnDemand
-  constant.PriceUnit:
-    enum:
-    - PerHour
-    - PerYear
-    type: string
-    x-enum-varnames:
-    - PerHour
-    - PerYear
   constant.ResourceType:
     enum:
     - VM
@@ -376,17 +333,6 @@ definitions:
     - VNet
     - DataDisk
     - Etc
-  cost.AllPriceInfoResult:
-    properties:
-      infoSource:
-        type: string
-      priceInfoList:
-        items:
-          $ref: '#/definitions/cost.PriceInfoResult'
-        type: array
-      resultCount:
-        type: integer
-    type: object
   cost.GetCostInfoResult:
     properties:
       category:
@@ -402,45 +348,6 @@ definitions:
       totalCost:
         type: number
       unit:
-        type: string
-    type: object
-  cost.PriceInfoResult:
-    properties:
-      calculatedMonthlyPrice:
-        type: string
-      currency:
-        $ref: '#/definitions/constant.PriceCurrency'
-      id:
-        type: integer
-      instanceType:
-        type: string
-      lastUpdatedAt:
-        type: string
-      memory:
-        type: string
-      originalPricePolicy:
-        type: string
-      osType:
-        type: string
-      price:
-        type: string
-      priceDescription:
-        type: string
-      pricePolicy:
-        $ref: '#/definitions/constant.PricePolicy'
-      productDescription:
-        type: string
-      providerName:
-        type: string
-      regionName:
-        type: string
-      storage:
-        type: string
-      unit:
-        $ref: '#/definitions/constant.PriceUnit'
-      vCpu:
-        type: string
-      zoneName:
         type: string
     type: object
   cost.UpdateCostInfoResult:
@@ -1344,27 +1251,48 @@ paths:
       tags:
       - '[Load Test Execution Management]'
   /api/v1/price/info:
-    post:
+    get:
       consumes:
       - application/json
       description: Retrieve pricing information for cloud resources based on specified
-        parameters. If saved data is more than 7 days, fetch new data and insert new
-        price data even if same price as before.
-      operationId: GetPriceInfo
+        query parameters. Returns price data based on provider, region, instance type,
+        vCPU, memory, and OS type. It offer instances with the lowest monthly prices
+        what in the database.
+      operationId: GetPriceInfos
       parameters:
-      - description: Request body containing get price information
-        in: body
-        name: body
+      - description: Cloud provider name - aws|alibaba|tencent|gcp|azure|ibm
+        in: query
+        name: providerName
         required: true
-        schema:
-          $ref: '#/definitions/app.GetPriceInfoReq'
+        type: string
+      - description: Region name
+        in: query
+        name: regionName
+        required: true
+        type: string
+      - description: Instance type
+        in: query
+        name: instanceType
+        type: string
+      - description: Number of vCPUs
+        in: query
+        name: vCpu
+        type: string
+      - description: Amount of memory
+        in: query
+        name: memory
+        type: string
+      - description: Operating system type
+        in: query
+        name: osType
+        type: string
       produces:
       - application/json
       responses:
         "200":
           description: Successfully retrieved pricing information
           schema:
-            $ref: '#/definitions/app.AntResponse-cost_AllPriceInfoResult'
+            $ref: '#/definitions/app.AntResponse-string'
         "400":
           description: Invalid request parameters
           schema:
@@ -1374,6 +1302,37 @@ paths:
           schema:
             $ref: '#/definitions/app.AntResponse-string'
       summary: Get Price Information
+      tags:
+      - Price Management
+    post:
+      consumes:
+      - application/json
+      description: Retrieve pricing information for cloud resources based on specified
+        parameters. If saved data is more than 7 days, fetch new data and insert new
+        price data even if same price as before.
+      operationId: UpdatePriceInfos
+      parameters:
+      - description: Request body containing get price information
+        in: body
+        name: body
+        required: true
+        schema:
+          $ref: '#/definitions/app.UpdatePriceInfosReq'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Successfully retrieved pricing information
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+        "400":
+          description: Invalid request parameters
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
+        "500":
+          description: Failed to retrieve pricing information
+          schema:
+            $ref: '#/definitions/app.AntResponse-string'
       tags:
       - '[Price Management]'
 swagger: "2.0"

--- a/internal/app/cost_handler.go
+++ b/internal/app/cost_handler.go
@@ -140,7 +140,7 @@ func (server *AntServer) updateCostInfos(c echo.Context) error {
 		StartDate:      startDate,
 		EndDate:        endDate,
 		CostResources:  costResources,
-		ConnectionName: "aws-us-east-1",
+		ConnectionName: req.ConnectionName,
 		AwsAdditionalInfo: cost.AwsAdditionalInfoParam{
 			OwnerId: req.AwsAdditionalInfo.OwnerId,
 			Regions: req.AwsAdditionalInfo.Regions,

--- a/internal/app/cost_handler.go
+++ b/internal/app/cost_handler.go
@@ -135,11 +135,12 @@ func (server *AntServer) updateCostInfos(c echo.Context) error {
 	endDate := time.Now().Truncate(24*time.Hour).AddDate(0, 0, 1)
 	startDate := endDate.AddDate(0, 0, -14)
 	param := cost.UpdateCostInfoParam{
-		MigrationId:   req.MigrationId,
-		Provider:      "aws",
-		StartDate:     startDate,
-		EndDate:       endDate,
-		CostResources: costResources,
+		MigrationId:    req.MigrationId,
+		Provider:       "aws",
+		StartDate:      startDate,
+		EndDate:        endDate,
+		CostResources:  costResources,
+		ConnectionName: "aws-us-east-1",
 		AwsAdditionalInfo: cost.AwsAdditionalInfoParam{
 			OwnerId: req.AwsAdditionalInfo.OwnerId,
 			Regions: req.AwsAdditionalInfo.Regions,

--- a/internal/app/cost_handler.go
+++ b/internal/app/cost_handler.go
@@ -12,46 +12,36 @@ import (
 
 // @Id GetPriceInfo
 // @Summary Get Price Information
-// @Description Retrieve pricing information for cloud resources based on specified parameters.
+// @Description Retrieve pricing information for cloud resources based on specified parameters. If saved data is more than 7 days, fetch new data and insert new price data even if same price as before.
 // @Tags [Price Management]
 // @Accept json
 // @Produce json
-// @Param regionName query string true "Name of the region"
-// @Param connectionName query string true "Name of the connection"
-// @Param providerName query string true "Name of the cloud provider"
-// @Param instanceType query string true "Type of the instance"
-// @Param zoneName query string false "Name of the zone"
-// @Param vCpu query string false "Number of virtual CPUs"
-// @Param memory query string false "Amount of memory. Don't need to pass unit like 'gb'"
-// @Param storage query string false "Amount of storage"
-// @Param osType query string false "Operating system type"
+// @Param body body app.GetPriceInfoReq true "Request body containing get price information"
 // @Success 200 {object} app.AntResponse[cost.AllPriceInfoResult] "Successfully retrieved pricing information"
 // @Failure 400 {object} app.AntResponse[string] "Invalid request parameters"
 // @Failure 500 {object} app.AntResponse[string] "Failed to retrieve pricing information"
-// @Router /api/v1/price/info [get]
-func (server *AntServer) getPriceInfo(c echo.Context) error {
+// @Router /api/v1/price/info [post]
+func (server *AntServer) getPriceInfos(c echo.Context) error {
 	var req GetPriceInfoReq
 	if err := c.Bind(&req); err != nil {
 		return errorResponseJson(http.StatusBadRequest, err.Error())
 	}
 
 	if strings.TrimSpace(req.RegionName) == "" ||
-		strings.TrimSpace(req.ConnectionName) == "" ||
 		strings.TrimSpace(req.ProviderName) == "" ||
 		strings.TrimSpace(req.InstanceType) == "" {
 		return errorResponseJson(http.StatusBadRequest, "Region Name, Connection Name, Provider Name, Instance type must be set")
 	}
 
 	arg := cost.GetPriceInfoParam{
-		ProviderName:   strings.TrimSpace(req.ProviderName),
-		ConnectionName: strings.TrimSpace(req.ConnectionName),
-		RegionName:     strings.TrimSpace(req.RegionName),
-		InstanceType:   strings.TrimSpace(req.InstanceType),
-		ZoneName:       strings.TrimSpace(req.ZoneName),
-		VCpu:           strings.TrimSpace(req.VCpu),
-		Memory:         strings.TrimSpace(req.Memory),
-		Storage:        strings.TrimSpace(req.Storage),
-		OsType:         strings.TrimSpace(req.OsType),
+		ProviderName: strings.TrimSpace(req.ProviderName),
+		RegionName:   strings.TrimSpace(req.RegionName),
+		InstanceType: strings.TrimSpace(req.InstanceType),
+		ZoneName:     strings.TrimSpace(req.ZoneName),
+		VCpu:         strings.TrimSpace(req.VCpu),
+		Memory:       strings.TrimSpace(req.Memory),
+		Storage:      strings.TrimSpace(req.Storage),
+		OsType:       strings.TrimSpace(req.OsType),
 	}
 
 	r, err := server.services.costService.GetPriceInfo(arg)
@@ -105,12 +95,11 @@ func (server *AntServer) updateCostInfo(c echo.Context) error {
 	endDate := time.Now().Truncate(24*time.Hour).AddDate(0, 0, 1)
 	startDate := endDate.AddDate(0, 0, -14)
 	param := cost.UpdateCostInfoParam{
-		MigrationId:    req.MigrationId,
-		Provider:       "aws",
-		ConnectionName: req.ConnectionName,
-		StartDate:      startDate,
-		EndDate:        endDate,
-		CostResources:  costResources,
+		MigrationId:   req.MigrationId,
+		Provider:      "aws",
+		StartDate:     startDate,
+		EndDate:       endDate,
+		CostResources: costResources,
 		AwsAdditionalInfo: cost.AwsAdditionalInfoParam{
 			OwnerId: req.AwsAdditionalInfo.OwnerId,
 			Regions: req.AwsAdditionalInfo.Regions,

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -2,16 +2,19 @@ package app
 
 import "github.com/cloud-barista/cm-ant/internal/core/common/constant"
 
-type GetPriceInfoReq struct {
+type UpdatePriceInfosReq struct {
 	ProviderName string `json:"providerName" validate:"required"`
 	RegionName   string `json:"regionName" validate:"required"`
 	InstanceType string `json:"instanceType" validate:"required"`
+}
 
-	ZoneName string `json:"zoneName,omitempty"`
-	VCpu     string `json:"vCpu,omitempty"`
-	Memory   string `json:"memory,omitempty"`
-	Storage  string `json:"storage,omitempty"`
-	OsType   string `json:"osType,omitempty"`
+type GetPriceInfosReq struct {
+	ProviderName string `query:"providerName" validate:"required"`
+	RegionName   string `query:"regionName" validate:"required"`
+	InstanceType string `query:"instanceType"`
+	VCpu         string `query:"vCpu"`
+	Memory       string `query:"memory"`
+	OsType       string `query:"osType"`
 }
 
 type UpdateCostInfoReq struct {

--- a/internal/app/cost_req.go
+++ b/internal/app/cost_req.go
@@ -3,16 +3,15 @@ package app
 import "github.com/cloud-barista/cm-ant/internal/core/common/constant"
 
 type GetPriceInfoReq struct {
-	ProviderName   string `query:"providerName" validate:"required"`
-	ConnectionName string `query:"connectionName" validate:"required"`
-	RegionName     string `query:"regionName" validate:"required"`
-	InstanceType   string `query:"instanceType" validate:"required"`
+	ProviderName string `json:"providerName" validate:"required"`
+	RegionName   string `json:"regionName" validate:"required"`
+	InstanceType string `json:"instanceType" validate:"required"`
 
-	ZoneName string `query:"zoneName,omitempty"`
-	VCpu     string `query:"vCpu,omitempty"`
-	Memory   string `query:"memory,omitempty"`
-	Storage  string `query:"storage,omitempty"`
-	OsType   string `query:"osType,omitempty"`
+	ZoneName string `json:"zoneName,omitempty"`
+	VCpu     string `json:"vCpu,omitempty"`
+	Memory   string `json:"memory,omitempty"`
+	Storage  string `json:"storage,omitempty"`
+	OsType   string `json:"osType,omitempty"`
 }
 
 type UpdateCostInfoReq struct {

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -67,7 +67,7 @@ func (server *AntServer) InitRouter() error {
 	{
 		priceRouter := versionRouter.Group("/price")
 		{
-			priceRouter.GET("/info", server.getPriceInfo)
+			priceRouter.POST("/info", server.getPriceInfos)
 		}
 
 		costRouter := versionRouter.Group("/cost")

--- a/internal/app/router.go
+++ b/internal/app/router.go
@@ -67,13 +67,14 @@ func (server *AntServer) InitRouter() error {
 	{
 		priceRouter := versionRouter.Group("/price")
 		{
-			priceRouter.POST("/info", server.getPriceInfos)
+			priceRouter.POST("/info", server.updatePriceInfos)
+			priceRouter.GET("/info", server.getPriceInfos)
 		}
 
 		costRouter := versionRouter.Group("/cost")
 		{
-			costRouter.POST("/info", server.updateCostInfo)
-			costRouter.GET("/info", server.getCostInfo)
+			costRouter.POST("/info", server.updateCostInfos)
+			costRouter.GET("/info", server.getCostInfos)
 		}
 	}
 

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -91,7 +91,8 @@ func initializeServices(repos *antRepositories, tbClient *tumblebug.TumblebugCli
 	loadServ := load.NewLoadService(repos.loadRepo, tbClient)
 
 	cc := cost.NewAwsCostExplorerSpiderCostCollector(sClient)
-	costServ := cost.NewCostService(repos.costRepo, sClient, cc)
+	pc := cost.NewSpiderPriceCollector(sClient)
+	costServ := cost.NewCostService(repos.costRepo, pc, cc)
 
 	return &antServices{
 		loadService: loadServ,

--- a/internal/core/cost/cost_collector.go
+++ b/internal/core/cost/cost_collector.go
@@ -15,7 +15,7 @@ import (
 )
 
 type CostCollector interface {
-	GetCostInfo(context.Context, UpdateCostInfoParam) (CostInfos, error)
+	GetCostInfos(context.Context, UpdateCostInfoParam) (CostInfos, error)
 }
 
 type AwsCostExplorerSpiderCostCollector struct {
@@ -114,7 +114,7 @@ func (a *AwsCostExplorerSpiderCostCollector) generateFilterValue(
 	return serviceValue, resourceIdValues, nil
 }
 
-func (a *AwsCostExplorerSpiderCostCollector) GetCostInfo(ctx context.Context, param UpdateCostInfoParam) (CostInfos, error) {
+func (a *AwsCostExplorerSpiderCostCollector) GetCostInfos(ctx context.Context, param UpdateCostInfoParam) (CostInfos, error) {
 	serviceFilterValue, resourceIdFilterValue, err := a.generateFilterValue(param.CostResources, param.AwsAdditionalInfo)
 	if err != nil {
 		utils.LogError("parsing service and resource id for filtering cost explorer value")

--- a/internal/core/cost/dtos.go
+++ b/internal/core/cost/dtos.go
@@ -1,0 +1,100 @@
+package cost
+
+import (
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+)
+
+type GetPriceInfoParam struct {
+	MigrationId  string
+	ProviderName string
+	RegionName   string
+	InstanceType string
+	ZoneName     string
+	VCpu         string
+	Memory       string
+	Storage      string
+	OsType       string
+	Unit         constant.PriceUnit
+	Currency     constant.PriceCurrency
+
+	TimeStandard time.Time
+	PricePolicy  constant.PricePolicy
+}
+
+type AllPriceInfoResult struct {
+	PriceInfoList []PriceInfoResult `json:"priceInfoList,omitempty"`
+	InfoSource    string            `json:"infoSource,omitempty"`
+	ResultCount   int64             `json:"resultCount"`
+}
+
+type PriceInfoResult struct {
+	ID           uint   `json:"id"`
+	ProviderName string `json:"providerName"`
+	RegionName   string `json:"regionName"`
+	InstanceType string `json:"instanceType"`
+
+	ZoneName               string                 `json:"zoneName,omitempty"`
+	VCpu                   string                 `json:"vCpu,omitempty"`
+	Memory                 string                 `json:"memory,omitempty"`
+	Storage                string                 `json:"storage,omitempty"`
+	OsType                 string                 `json:"osType,omitempty"`
+	ProductDescription     string                 `json:"productDescription,omitempty"`
+	OriginalPricePolicy    string                 `json:"originalPricePolicy,omitempty"`
+	PricePolicy            constant.PricePolicy   `json:"pricePolicy,omitempty"`
+	Unit                   constant.PriceUnit     `json:"unit,omitempty"`
+	Currency               constant.PriceCurrency `json:"currency,omitempty"`
+	Price                  string                 `json:"price,omitempty"`
+	CalculatedMonthlyPrice string                 `json:"calculatedMonthlyPrice,omitempty"`
+	PriceDescription       string                 `json:"priceDescription,omitempty"`
+	LastUpdatedAt          time.Time              `json:"lastUpdatedAt,omitempty"`
+}
+
+type UpdateCostInfoParam struct {
+	MigrationId       string
+	Provider          string // currently only aws
+	ConnectionName    string
+	StartDate         time.Time
+	EndDate           time.Time
+	CostResources     []CostResourceParam
+	AwsAdditionalInfo AwsAdditionalInfoParam
+}
+
+type CostResourceParam struct {
+	ResourceType constant.ResourceType
+	ResourceIds  []string
+}
+
+type AwsAdditionalInfoParam struct {
+	OwnerId string   `json:"ownerId"`
+	Regions []string `json:"regions"`
+}
+
+type UpdateCostInfoResult struct {
+	FetchedDataCount  int64 `json:"fetchedDataCount"`
+	UpdatedDataCount  int64 `json:"updatedDataCount"`
+	InsertedDataCount int64 `insertedDataCount`
+}
+
+type GetCostInfoParam struct {
+	StartDate           time.Time
+	EndDate             time.Time
+	MigrationIds        []string
+	Providers           []string
+	ResourceTypes       []constant.ResourceType
+	ResourceIds         []string
+	CostAggregationType constant.CostAggregationType
+	DateOrder           constant.OrderType
+	ResourceTypeOrder   constant.OrderType
+}
+
+type GetCostInfoResult struct {
+	Provider         string    `json:"provider"`
+	ResourceType     string    `json:"resourceType"`
+	Category         string    `json:"category"`
+	ActualResourceId string    `json:"resourceId"`
+	Unit             string    `json:"unit"`
+	Date             time.Time `json:"date"`
+	TotalCost        float64   `json:"totalCost"`
+}

--- a/internal/core/cost/dtos.go
+++ b/internal/core/cost/dtos.go
@@ -6,18 +6,24 @@ import (
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
 )
 
-type GetPriceInfoParam struct {
+type UpdatePriceInfosParam struct {
 	MigrationId  string
 	ProviderName string
 	RegionName   string
 	InstanceType string
-	ZoneName     string
-	VCpu         string
-	Memory       string
-	Storage      string
-	OsType       string
-	Unit         constant.PriceUnit
-	Currency     constant.PriceCurrency
+
+	TimeStandard time.Time
+	PricePolicy  constant.PricePolicy
+}
+
+type GetPriceInfosParam struct {
+	ProviderName string
+	RegionName   string
+	InstanceType string
+
+	VCpu   string
+	Memory string
+	OsType string
 
 	TimeStandard time.Time
 	PricePolicy  constant.PricePolicy
@@ -25,7 +31,6 @@ type GetPriceInfoParam struct {
 
 type AllPriceInfoResult struct {
 	PriceInfoList []PriceInfoResult `json:"priceInfoList,omitempty"`
-	InfoSource    string            `json:"infoSource,omitempty"`
 	ResultCount   int64             `json:"resultCount"`
 }
 
@@ -35,7 +40,6 @@ type PriceInfoResult struct {
 	RegionName   string `json:"regionName"`
 	InstanceType string `json:"instanceType"`
 
-	ZoneName               string                 `json:"zoneName,omitempty"`
 	VCpu                   string                 `json:"vCpu,omitempty"`
 	Memory                 string                 `json:"memory,omitempty"`
 	Storage                string                 `json:"storage,omitempty"`
@@ -46,7 +50,7 @@ type PriceInfoResult struct {
 	Unit                   constant.PriceUnit     `json:"unit,omitempty"`
 	Currency               constant.PriceCurrency `json:"currency,omitempty"`
 	Price                  string                 `json:"price,omitempty"`
-	CalculatedMonthlyPrice string                 `json:"calculatedMonthlyPrice,omitempty"`
+	CalculatedMonthlyPrice float64                `json:"calculatedMonthlyPrice,omitempty"`
 	PriceDescription       string                 `json:"priceDescription,omitempty"`
 	LastUpdatedAt          time.Time              `json:"lastUpdatedAt,omitempty"`
 }

--- a/internal/core/cost/models.go
+++ b/internal/core/cost/models.go
@@ -7,21 +7,22 @@ import (
 	"gorm.io/gorm"
 )
 
+type PriceInfos []*PriceInfo
+
 type PriceInfo struct {
 	gorm.Model
-	ProviderName       string
-	ConnectionName     string
-	RegionName         string
-	InstanceType       string
-	ZoneName           string
-	VCpu               string
-	Memory             string
-	MemoryUnit         constant.MemoryUnit
-	OriginalMemory     string
-	Storage            string
-	OsType             string
-	ProductDescription string
-
+	ProviderName           string
+	RegionName             string
+	InstanceType           string
+	ZoneName               string
+	VCpu                   string
+	Memory                 string
+	MemoryUnit             constant.MemoryUnit
+	OriginalMemory         string
+	Storage                string
+	OsType                 string
+	ProductDescription     string
+	OriginalPricePolicy    string
 	PricePolicy            constant.PricePolicy
 	Price                  string
 	Currency               constant.PriceCurrency

--- a/internal/core/cost/models.go
+++ b/internal/core/cost/models.go
@@ -11,16 +11,16 @@ type PriceInfos []*PriceInfo
 
 type PriceInfo struct {
 	gorm.Model
-	ProviderName           string
-	RegionName             string
-	InstanceType           string
+	ProviderName           string `gorm:"index"`
+	RegionName             string `gorm:"index"`
+	InstanceType           string `gorm:"index"`
 	ZoneName               string
-	VCpu                   string
-	Memory                 string
+	VCpu                   string `gorm:"index"`
+	Memory                 string `gorm:"index"`
 	MemoryUnit             constant.MemoryUnit
 	OriginalMemory         string
 	Storage                string
-	OsType                 string
+	OsType                 string `gorm:"index"`
 	ProductDescription     string
 	OriginalPricePolicy    string
 	PricePolicy            constant.PricePolicy
@@ -29,7 +29,7 @@ type PriceInfo struct {
 	Unit                   constant.PriceUnit
 	OriginalUnit           string
 	OriginalCurrency       string
-	CalculatedMonthlyPrice string
+	CalculatedMonthlyPrice float64 `gorm:"index"`
 	PriceDescription       string
 }
 

--- a/internal/core/cost/price_collector.go
+++ b/internal/core/cost/price_collector.go
@@ -1,0 +1,303 @@
+package cost
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"unicode"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/spider"
+	"github.com/cloud-barista/cm-ant/internal/utils"
+)
+
+type PriceCollector interface {
+	GetPriceInfos(context.Context, GetPriceInfoParam) (PriceInfos, error)
+}
+
+var (
+	onDemandPricingPolicyMap = map[string]string{
+		"aws":     "OnDemand",
+		"gcp":     "OnDemand",
+		"azure":   "Consumption",
+		"tencent": "POSTPAID_BY_HOUR",
+		"alibaba": "PayAsYouGo",
+		"ibm":     "quantity_tier=1",
+		"ncp":     "Monthly Flat Rate",
+		"ncpvpc":  "Monthly Flat Rate",
+	}
+
+	priceValidator = map[string]func(res *PriceInfo) bool{
+		"aws": func(res *PriceInfo) bool {
+			return !strings.Contains(res.PriceDescription, "Reservation")
+		},
+		"gcp":   func(res *PriceInfo) bool { return true },
+		"azure": func(res *PriceInfo) bool { return true },
+		"tencent": func(res *PriceInfo) bool {
+			return res.OriginalPricePolicy == onDemandPricingPolicyMap[res.ProviderName]
+		},
+		"alibaba": func(res *PriceInfo) bool { return true },
+		"ibm": func(res *PriceInfo) bool {
+			return strings.Contains(res.OriginalUnit, "Instance-Hour")
+		},
+		"ncp":    func(res *PriceInfo) bool { return true },
+		"ncpvpc": func(res *PriceInfo) bool { return true },
+	}
+
+	units = map[string]bool{
+		"instance-hour":               true,
+		"hour":                        true,
+		"yrs":                         false,
+		"hrs":                         true,
+		"1 hour":                      true,
+		"virtual processor core-hour": true,
+	}
+)
+
+type SpiderPriceCollector struct {
+	sc *spider.SpiderClient
+}
+
+func NewSpiderPriceCollector(sc *spider.SpiderClient) PriceCollector {
+	return &SpiderPriceCollector{
+		sc: sc,
+	}
+}
+
+func (s *SpiderPriceCollector) GetPriceInfos(ctx context.Context, param GetPriceInfoParam) (PriceInfos, error) {
+	connectionName := fmt.Sprintf("%s-%s", strings.ToLower(param.ProviderName), strings.ToLower(param.RegionName))
+
+	req := spider.PriceInfoReq{
+		ConnectionName: connectionName,
+		FilterList:     s.generateFilterList(param),
+	}
+
+	result, err := s.sc.GetPriceInfoWithContext(ctx, param.RegionName, req)
+
+	if err != nil {
+
+		if strings.Contains(err.Error(), "you don't have any permission") {
+			return nil, fmt.Errorf("you don't have permission to query the price for %s", param.ProviderName)
+		}
+		return nil, err
+	}
+
+	createdPriceInfo := make([]*PriceInfo, 0)
+	if result.CloudPriceList != nil {
+		for i := range result.CloudPriceList {
+			p := result.CloudPriceList[i]
+
+			if p.PriceList != nil {
+				for j := range p.PriceList {
+
+					pl := p.PriceList[j]
+
+					productInfo := pl.ProductInfo
+					vCpu := s.naChecker(productInfo.Vcpu)
+					originalMemory := s.naChecker(productInfo.Memory)
+
+					if vCpu == "" || originalMemory == "" {
+						continue
+					}
+
+					memory, memoryUnit := s.splitMemory(originalMemory)
+					zoneName := s.naChecker(productInfo.ZoneName)
+					osType := s.naChecker(productInfo.OperatingSystem)
+					storage := s.naChecker(productInfo.Storage)
+					productDescription := s.naChecker(productInfo.Description)
+
+					var price, originalCurrency, originalUnit, priceDescription string
+					var unit constant.PriceUnit
+					var currency constant.PriceCurrency
+
+					priceInfo := pl.PriceInfo
+
+					if priceInfo.PricingPolicies != nil {
+						for k := range priceInfo.PricingPolicies {
+							policy := priceInfo.PricingPolicies[k]
+							originalPricePolicy := s.naChecker(policy.PricingPolicy)
+							priceDescription = s.naChecker(policy.Description)
+							originalCurrency = s.naChecker(policy.Currency)
+							originalUnit = s.naChecker(policy.Unit)
+							unit = s.parseUnit(originalUnit)
+							currency = s.parseCurrency(policy.Currency)
+							convertedPrice, err := strconv.ParseFloat(policy.Price, 64)
+							if err != nil {
+								continue
+							}
+
+							if convertedPrice == float64(0) {
+								continue
+							}
+							price = s.naChecker(policy.Price)
+
+							if price == "" {
+								continue
+							}
+
+							pi := PriceInfo{
+								ProviderName:           param.ProviderName,
+								RegionName:             param.RegionName,
+								InstanceType:           param.InstanceType,
+								ZoneName:               zoneName,
+								VCpu:                   vCpu,
+								OriginalMemory:         originalMemory,
+								Memory:                 memory,
+								MemoryUnit:             memoryUnit,
+								Storage:                storage,
+								OsType:                 osType,
+								ProductDescription:     productDescription,
+								OriginalPricePolicy:    originalPricePolicy,
+								PricePolicy:            constant.OnDemand,
+								Price:                  price,
+								Currency:               currency,
+								Unit:                   unit,
+								OriginalUnit:           originalUnit,
+								OriginalCurrency:       originalCurrency,
+								PriceDescription:       priceDescription,
+								CalculatedMonthlyPrice: s.calculatePrice(price, unit),
+							}
+
+							if !priceValidator[param.ProviderName](&pi) {
+								continue
+							}
+
+							createdPriceInfo = append(createdPriceInfo, &pi)
+						}
+					}
+
+				}
+			}
+		}
+	}
+
+	sort.Slice(createdPriceInfo, func(i, j int) bool {
+		return createdPriceInfo[i].Price < createdPriceInfo[j].Price
+	})
+
+	return createdPriceInfo, nil
+}
+
+func (s *SpiderPriceCollector) generateFilterList(param GetPriceInfoParam) []spider.FilterReq {
+
+	providerName := strings.ToLower(param.ProviderName)
+	param.ProviderName = providerName
+
+	ret := []spider.FilterReq{
+		{
+			Key:   "instanceType",
+			Value: param.InstanceType,
+		},
+		{
+			Key:   "pricingPolicy",
+			Value: onDemandPricingPolicyMap[providerName],
+		},
+		{
+			Key:   "regionName",
+			Value: param.RegionName,
+		},
+	}
+
+	return ret
+}
+
+func (s *SpiderPriceCollector) parseUnit(p string) constant.PriceUnit {
+	ret := constant.PerHour
+
+	if p == "" {
+		return ret
+	}
+
+	a := strings.ToLower(p)
+
+	if v, ok := units[a]; v && ok {
+		return ret
+	}
+
+	return constant.PerYear
+}
+
+func (s *SpiderPriceCollector) splitMemory(input string) (string, constant.MemoryUnit) {
+	if input == "" {
+		return "", ""
+	}
+
+	var numberPart string
+	var unitPart string
+
+	for _, char := range input {
+		if unicode.IsDigit(char) || char == '.' {
+			numberPart += string(char)
+		} else {
+			unitPart += string(char)
+		}
+	}
+
+	number, err := strconv.ParseFloat(strings.TrimSpace(numberPart), 64)
+	if err != nil {
+		utils.LogErrorf("error while split memory : %s", err.Error())
+		return "", ""
+	}
+
+	num := fmt.Sprintf("%.0f", number)
+	unit := strings.ToLower(strings.TrimSpace(unitPart))
+
+	var memoryUnit constant.MemoryUnit
+	if unit == "" || unit == "gb" || unit == "gib" {
+		memoryUnit = constant.GIB
+	} else {
+		memoryUnit = constant.GIB
+	}
+	return num, memoryUnit
+}
+
+func (s *SpiderPriceCollector) parseCurrency(p string) constant.PriceCurrency {
+	if p == "" {
+		return constant.USD
+	}
+
+	switch strings.ToLower(p) {
+	case "usd":
+		return constant.USD
+	case "krw":
+		return constant.KRW
+	}
+
+	return constant.USD
+}
+
+func (s *SpiderPriceCollector) calculatePrice(p string, unit constant.PriceUnit) string {
+	if p == "" {
+		return "0.000000"
+	}
+
+	value, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
+	if err != nil {
+		return "0.000000"
+	}
+
+	var monthlyCostStr string
+	if unit == constant.PerHour {
+
+		monthlyCost := value * 30 * 24
+		monthlyCostStr = fmt.Sprintf("%.6f", monthlyCost)
+	} else if unit == constant.PerYear {
+		monthlyCost := value
+		monthlyCostStr = fmt.Sprintf("%.6f", monthlyCost)
+	}
+
+	return monthlyCostStr
+}
+
+func (s *SpiderPriceCollector) naChecker(originalValue string) string {
+	trimed := strings.TrimSpace(originalValue)
+	lower := strings.ToLower(trimed)
+
+	if lower == "na" || lower == "n/a" || lower == "0" {
+		return ""
+	}
+
+	return trimed
+}

--- a/internal/core/cost/repository.go
+++ b/internal/core/cost/repository.go
@@ -3,6 +3,7 @@ package cost
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
 	"gorm.io/gorm"
@@ -35,43 +36,40 @@ func (r *CostRepository) execInTransaction(ctx context.Context, fn func(*gorm.DB
 	return tx.Commit().Error
 }
 
-func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param GetPriceInfoParam) (PriceInfos, error) {
+func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param GetPriceInfosParam) (PriceInfos, error) {
 	var priceInfoList []*PriceInfo
 
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 		q := d.Model(&PriceInfo{}).
 			Where(
-				"provider_name = ? AND region_name = ? AND instance_type = ? AND price_policy = ? AND updated_at >= ?",
-				param.ProviderName, param.RegionName, param.InstanceType, param.PricePolicy, param.TimeStandard,
+				"price_policy = ? AND updated_at >= ?",
+				param.PricePolicy, param.TimeStandard,
 			).
-			Order("price asc")
+			Order("calculated_monthly_price asc").
+			Limit(8)
 
-		if param.ZoneName != "" {
-			q = q.Where("zone_name = ?", param.ZoneName)
+		if param.ProviderName != "" {
+			q = q.Where("LOWER(provider_name) = ?", strings.ToLower(param.ProviderName))
+		}
+
+		if param.RegionName != "" {
+			q = q.Where("LOWER(region_name) = ?", strings.ToLower(param.RegionName))
+		}
+
+		if param.InstanceType != "" {
+			q = q.Where("LOWER(instance_type) = ?", strings.ToLower(param.InstanceType))
 		}
 
 		if param.VCpu != "" {
-			q = q.Where("v_cpu = ?", param.VCpu)
+			q = q.Where("LOWER(v_cpu) = ?", strings.ToLower(param.VCpu))
 		}
 
 		if param.Memory != "" {
-			q = q.Where("memory = ?", param.Memory)
-		}
-
-		if param.Storage != "" {
-			q = q.Where("storage = ?", param.Storage)
+			q = q.Where("LOWER(memory) = ?", strings.ToLower(param.Memory))
 		}
 
 		if param.OsType != "" {
-			q = q.Where("os_type = ?", param.OsType)
-		}
-
-		if param.Unit != "" {
-			q = q.Where("unit = ?", param.Unit)
-		}
-
-		if param.Currency != "" {
-			q = q.Where("currency = ?", param.Currency)
+			q = q.Where("LOWER(os_type) = ?", strings.ToLower(param.OsType))
 		}
 
 		if err := q.Find(&priceInfoList).Error; err != nil {
@@ -82,18 +80,44 @@ func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param 
 	})
 
 	return priceInfoList, err
+}
+
+func (r *CostRepository) CountMatchingPriceInfoList(ctx context.Context, param UpdatePriceInfosParam) (int64, error) {
+	var totalCount int64
+
+	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
+		q := d.Model(&PriceInfo{}).
+			Where(
+				"LOWER(provider_name) = ? AND LOWER(region_name) = ? AND price_policy = ? AND updated_at >= ?",
+				strings.ToLower(param.ProviderName), strings.ToLower(param.RegionName), param.PricePolicy, param.TimeStandard,
+			)
+
+		if param.InstanceType != "" {
+			q = q.Where("LOWER(instance_type) = ?", strings.ToLower(param.InstanceType))
+		}
+
+		return q.Count(&totalCount).Error
+	})
+
+	return totalCount, err
 
 }
 
-func (r *CostRepository) InsertAllResult(ctx context.Context, param GetPriceInfoParam, created PriceInfos) error {
+func (r *CostRepository) BatchInsertAllResult(ctx context.Context, param UpdatePriceInfosParam, created PriceInfos) error {
 
+	batchSize := 100
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
-		err := d.Create(created).Error
+		for i := 0; i < len(created); i += batchSize {
+			end := i + batchSize
+			if end > len(created) {
+				end = len(created) // 데이터의 끝을 넘어가지 않도록 조정
+			}
 
-		if err != nil {
-			return err
+			batch := created[i:end]
+			if err := d.Create(&batch).Error; err != nil {
+				return err
+			}
 		}
-
 		return nil
 	})
 

--- a/internal/core/cost/repository.go
+++ b/internal/core/cost/repository.go
@@ -35,14 +35,14 @@ func (r *CostRepository) execInTransaction(ctx context.Context, fn func(*gorm.DB
 	return tx.Commit().Error
 }
 
-func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param GetPriceInfoParam) ([]PriceInfo, error) {
-	var priceInfoList []PriceInfo
+func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param GetPriceInfoParam) (PriceInfos, error) {
+	var priceInfoList []*PriceInfo
 
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
 		q := d.Model(&PriceInfo{}).
 			Where(
-				"provider_name = ? AND connection_name = ? AND region_name = ? AND instance_type = ? AND price_policy = ? AND updated_at >= ?",
-				param.ProviderName, param.ConnectionName, param.RegionName, param.InstanceType, param.PricePolicy, param.TimeStandard,
+				"provider_name = ? AND region_name = ? AND instance_type = ? AND price_policy = ? AND updated_at >= ?",
+				param.ProviderName, param.RegionName, param.InstanceType, param.PricePolicy, param.TimeStandard,
 			).
 			Order("price asc")
 
@@ -85,50 +85,10 @@ func (r *CostRepository) GetAllMatchingPriceInfoList(ctx context.Context, param 
 
 }
 
-func (r *CostRepository) InsertAllResult(ctx context.Context, param GetPriceInfoParam, created []*PriceInfo) error {
+func (r *CostRepository) InsertAllResult(ctx context.Context, param GetPriceInfoParam, created PriceInfos) error {
 
 	err := r.execInTransaction(ctx, func(d *gorm.DB) error {
-		q := d.Model(&PriceInfo{}).
-			Where(
-				"provider_name = ? AND connection_name = ? AND region_name = ? AND instance_type = ? AND price_policy = ? AND updated_at < ?",
-				param.ProviderName, param.ConnectionName, param.RegionName, param.InstanceType, param.PricePolicy, param.TimeStandard,
-			)
-
-		if param.ZoneName != "" {
-			q = q.Where("zone_name = ?", param.ZoneName)
-		}
-
-		if param.VCpu != "" {
-			q = q.Where("v_cpu = ?", param.VCpu)
-		}
-
-		if param.Memory != "" {
-			q = q.Where("memory = ?", param.Memory)
-		}
-
-		if param.Storage != "" {
-			q = q.Where("storage = ?", param.Storage)
-		}
-
-		if param.OsType != "" {
-			q = q.Where("os_type = ?", param.OsType)
-		}
-
-		if param.Unit != "" {
-			q = q.Where("unit = ?", param.Unit)
-		}
-
-		if param.Currency != "" {
-			q = q.Where("currency = ?", param.Currency)
-		}
-
-		err := q.Delete(&PriceInfo{}).Error
-
-		if err != nil {
-			return err
-		}
-
-		err = d.Create(created).Error
+		err := d.Create(created).Error
 
 		if err != nil {
 			return err

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -25,8 +25,40 @@ func NewCostService(costRepo *CostRepository, priceCollector PriceCollector, cos
 	}
 }
 
-func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+func (c *CostService) UpdatePriceInfos(param UpdatePriceInfosParam) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	param.TimeStandard = time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
+	param.PricePolicy = constant.OnDemand
+
+	count, err := c.costRepo.CountMatchingPriceInfoList(ctx, param)
+	if err != nil {
+		return err
+	}
+
+	if count <= int64(0) {
+		resList, err := c.priceCollector.GetPriceInfos(ctx, param)
+
+		if err != nil {
+			if strings.Contains(err.Error(), "you don't have any permission") {
+				return fmt.Errorf("you don't have permission to query the price for %s", param.ProviderName)
+			}
+			return err
+		}
+
+		if len(resList) > 0 {
+			err := c.costRepo.BatchInsertAllResult(ctx, param, resList)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (c *CostService) GetPriceInfos(param GetPriceInfosParam) (AllPriceInfoResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
 
 	param.TimeStandard = time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
@@ -34,21 +66,20 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 
 	var res AllPriceInfoResult
 
-	priceInfoList, err := c.costRepo.GetAllMatchingPriceInfoList(ctx, param)
+	priceInfos, err := c.costRepo.GetAllMatchingPriceInfoList(ctx, param)
 	if err != nil {
 		return res, err
 	}
 
-	pil := make([]PriceInfoResult, 0)
+	priceInfoList := make([]PriceInfoResult, 0)
 
-	if len(priceInfoList) > 0 {
-		for _, v := range priceInfoList {
-			r := PriceInfoResult{
+	if len(priceInfos) > 0 {
+		for _, v := range priceInfos {
+			result := PriceInfoResult{
 				ID:                     v.ID,
 				ProviderName:           v.ProviderName,
 				RegionName:             v.RegionName,
 				InstanceType:           v.InstanceType,
-				ZoneName:               v.ZoneName,
 				VCpu:                   v.VCpu,
 				Memory:                 fmt.Sprintf("%s %s", v.Memory, v.MemoryUnit),
 				Storage:                v.Storage,
@@ -63,58 +94,12 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 				PriceDescription:       v.PriceDescription,
 				LastUpdatedAt:          v.UpdatedAt,
 			}
-			pil = append(pil, r)
+			priceInfoList = append(priceInfoList, result)
 		}
 
-		res.InfoSource = "db"
-		res.PriceInfoList = pil
-		res.ResultCount = int64(len(pil))
+		res.PriceInfoList = priceInfoList
+		res.ResultCount = int64(len(priceInfoList))
 
-		return res, nil
-	}
-
-	resList, err := c.priceCollector.GetPriceInfos(ctx, param)
-
-	if err != nil {
-		if strings.Contains(err.Error(), "you don't have any permission") {
-			return res, fmt.Errorf("you don't have permission to query the price for %s", param.ProviderName)
-		}
-		return res, err
-	}
-
-	if len(resList) > 0 {
-		err := c.costRepo.InsertAllResult(ctx, param, resList)
-		if err != nil {
-			return res, nil
-		}
-
-		for _, v := range resList {
-			r := PriceInfoResult{
-				ID:                     v.ID,
-				ProviderName:           v.ProviderName,
-				RegionName:             v.RegionName,
-				InstanceType:           v.InstanceType,
-				ZoneName:               v.ZoneName,
-				VCpu:                   v.VCpu,
-				Memory:                 fmt.Sprintf("%s %s", v.Memory, v.MemoryUnit),
-				Storage:                v.Storage,
-				OsType:                 v.OsType,
-				ProductDescription:     v.ProductDescription,
-				OriginalPricePolicy:    v.OriginalPricePolicy,
-				PricePolicy:            v.PricePolicy,
-				Unit:                   v.Unit,
-				Currency:               v.Currency,
-				Price:                  v.Price,
-				CalculatedMonthlyPrice: v.CalculatedMonthlyPrice,
-				PriceDescription:       v.PriceDescription,
-				LastUpdatedAt:          v.UpdatedAt,
-			}
-			pil = append(pil, r)
-		}
-
-		res.InfoSource = "api"
-		res.PriceInfoList = pil
-		res.ResultCount = int64(len(pil))
 		return res, nil
 	}
 

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -4,93 +4,32 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strconv"
 	"strings"
 	"time"
-	"unicode"
 
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
-	"github.com/cloud-barista/cm-ant/internal/infra/outbound/spider"
 	"github.com/cloud-barista/cm-ant/internal/utils"
 )
 
 type CostService struct {
-	costRepo      *CostRepository
-	spiderClient  *spider.SpiderClient
-	costCollector CostCollector
+	costRepo       *CostRepository
+	priceCollector PriceCollector
+	costCollector  CostCollector
 }
 
-func NewCostService(costRepo *CostRepository, client *spider.SpiderClient, costCollector CostCollector) *CostService {
+func NewCostService(costRepo *CostRepository, priceCollector PriceCollector, costCollector CostCollector) *CostService {
 	return &CostService{
-		costRepo:      costRepo,
-		spiderClient:  client,
-		costCollector: costCollector,
+		costRepo:       costRepo,
+		priceCollector: priceCollector,
+		costCollector:  costCollector,
 	}
-}
-
-var onDemandPricingPolicyMap = map[string]string{
-	"aws":     "OnDemand",
-	"gcp":     "OnDemand",
-	"azure":   "Consumption",
-	"tencent": "POSTPAID_BY_HOUR",
-	"alibaba": "PayAsYouGo",
-	"ibm":     "quantity_tier=1",
-	"ncp":     "Monthly Flat Rate",
-	"ncpvpc":  "Monthly Flat Rate",
-}
-
-type GetPriceInfoParam struct {
-	MigrationId    string
-	ProviderName   string
-	ConnectionName string
-	RegionName     string
-	InstanceType   string
-	ZoneName       string
-	VCpu           string
-	Memory         string
-	Storage        string
-	OsType         string
-	Unit           constant.PriceUnit
-	Currency       constant.PriceCurrency
-
-	TimeStandard time.Time
-	PricePolicy  constant.PricePolicy
-}
-
-type AllPriceInfoResult struct {
-	PriceInfoList []PriceInfoResult `json:"priceInfoList,omitempty"`
-	InfoSource    string            `json:"infoSource,omitempty"`
-	ResultCount   int64             `json:"resultCount"`
-}
-
-type PriceInfoResult struct {
-	ID             uint   `json:"id"`
-	ProviderName   string `json:"providerName"`
-	ConnectionName string `json:"connectionName"`
-	RegionName     string `json:"regionName"`
-	InstanceType   string `json:"instanceType"`
-
-	ZoneName           string `json:"zoneName,omitempty"`
-	VCpu               string `json:"vCpu,omitempty"`
-	Memory             string `json:"memory,omitempty"`
-	Storage            string `json:"storage,omitempty"`
-	OsType             string `json:"osType,omitempty"`
-	ProductDescription string `json:"productDescription,omitempty"`
-
-	PricePolicy            constant.PricePolicy   `json:"pricePolicy,omitempty"`
-	Unit                   constant.PriceUnit     `json:"unit,omitempty"`
-	Currency               constant.PriceCurrency `json:"currency,omitempty"`
-	Price                  string                 `json:"price,omitempty"`
-	CalculatedMonthlyPrice string                 `json:"calculatedMonthlyPrice,omitempty"`
-	PriceDescription       string                 `json:"priceDescription,omitempty"`
-	LastUpdatedAt          time.Time              `json:"lastUpdatedAt,omitempty"`
 }
 
 func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
 	defer cancel()
 
-	param.TimeStandard = time.Now().AddDate(0, 0, -3).Truncate(24 * time.Hour)
+	param.TimeStandard = time.Now().AddDate(0, 0, -7).Truncate(24 * time.Hour)
 	param.PricePolicy = constant.OnDemand
 
 	var res AllPriceInfoResult
@@ -103,12 +42,10 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 	pil := make([]PriceInfoResult, 0)
 
 	if len(priceInfoList) > 0 {
-
 		for _, v := range priceInfoList {
 			r := PriceInfoResult{
 				ID:                     v.ID,
 				ProviderName:           v.ProviderName,
-				ConnectionName:         v.ConnectionName,
 				RegionName:             v.RegionName,
 				InstanceType:           v.InstanceType,
 				ZoneName:               v.ZoneName,
@@ -117,6 +54,7 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 				Storage:                v.Storage,
 				OsType:                 v.OsType,
 				ProductDescription:     v.ProductDescription,
+				OriginalPricePolicy:    v.OriginalPricePolicy,
 				PricePolicy:            v.PricePolicy,
 				Unit:                   v.Unit,
 				Currency:               v.Currency,
@@ -135,116 +73,25 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 		return res, nil
 	}
 
-	req := spider.PriceInfoReq{
-		ConnectionName: param.ConnectionName,
-		FilterList:     generateFilterList(param),
-	}
-
-	result, err := c.spiderClient.GetPriceInfoWithContext(ctx, param.RegionName, req)
+	resList, err := c.priceCollector.GetPriceInfos(ctx, param)
 
 	if err != nil {
-
 		if strings.Contains(err.Error(), "you don't have any permission") {
 			return res, fmt.Errorf("you don't have permission to query the price for %s", param.ProviderName)
 		}
 		return res, err
 	}
 
-	createdPriceInfo := make([]*PriceInfo, 0)
-	if result.CloudPriceList != nil {
-		for i := range result.CloudPriceList {
-			p := result.CloudPriceList[i]
-
-			if p.PriceList != nil {
-				for j := range p.PriceList {
-
-					pl := p.PriceList[j]
-					productInfo := pl.ProductInfo
-					vCpu := naChecker(productInfo.Vcpu)
-					originalMemory := naChecker(productInfo.Memory)
-
-					if vCpu == "" || originalMemory == "" {
-						continue
-					}
-
-					memory, memoryUnit := splitMemory(originalMemory)
-					zoneName := naChecker(productInfo.ZoneName)
-					osType := naChecker(productInfo.OperatingSystem)
-					storage := naChecker(productInfo.Storage)
-					productDescription := naChecker(productInfo.Description)
-
-					var price, originalCurrency, originalUnit, priceDescription string
-					var unit constant.PriceUnit
-					var currency constant.PriceCurrency
-
-					priceInfo := pl.PriceInfo
-
-					if priceInfo.PricingPolicies != nil {
-						for k := range priceInfo.PricingPolicies {
-							policy := priceInfo.PricingPolicies[k]
-							convertedPrice, err := strconv.ParseFloat(policy.Price, 64)
-							if err != nil {
-								continue
-							}
-
-							if convertedPrice == float64(0) {
-								continue
-							}
-							price = naChecker(policy.Price)
-
-							if price == "" {
-								continue
-							}
-
-							originalCurrency = naChecker(policy.Currency)
-							originalUnit = naChecker(policy.Unit)
-							unit = parseUnit(originalUnit)
-							currency = parseCurrency(originalUnit)
-							priceDescription = naChecker(policy.Description)
-
-							pi := PriceInfo{
-								ProviderName:           param.ProviderName,
-								ConnectionName:         param.ConnectionName,
-								RegionName:             param.RegionName,
-								InstanceType:           param.InstanceType,
-								ZoneName:               zoneName,
-								VCpu:                   vCpu,
-								OriginalMemory:         originalMemory,
-								Memory:                 memory,
-								MemoryUnit:             memoryUnit,
-								Storage:                storage,
-								OsType:                 osType,
-								ProductDescription:     productDescription,
-								PricePolicy:            constant.OnDemand,
-								Price:                  price,
-								Currency:               currency,
-								Unit:                   unit,
-								OriginalUnit:           originalUnit,
-								OriginalCurrency:       originalCurrency,
-								PriceDescription:       priceDescription,
-								CalculatedMonthlyPrice: calculatePrice(price, unit),
-							}
-
-							createdPriceInfo = append(createdPriceInfo, &pi)
-						}
-					}
-
-				}
-			}
-		}
-	}
-
-	if len(createdPriceInfo) > 0 {
-		err := c.costRepo.InsertAllResult(ctx, param, createdPriceInfo)
+	if len(resList) > 0 {
+		err := c.costRepo.InsertAllResult(ctx, param, resList)
 		if err != nil {
 			return res, nil
 		}
 
-		for _, v := range createdPriceInfo {
+		for _, v := range resList {
 			r := PriceInfoResult{
 				ID:                     v.ID,
 				ProviderName:           v.ProviderName,
-				ConnectionName:         v.ConnectionName,
 				RegionName:             v.RegionName,
 				InstanceType:           v.InstanceType,
 				ZoneName:               v.ZoneName,
@@ -253,11 +100,13 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 				Storage:                v.Storage,
 				OsType:                 v.OsType,
 				ProductDescription:     v.ProductDescription,
+				OriginalPricePolicy:    v.OriginalPricePolicy,
 				PricePolicy:            v.PricePolicy,
 				Unit:                   v.Unit,
 				Currency:               v.Currency,
 				Price:                  v.Price,
 				CalculatedMonthlyPrice: v.CalculatedMonthlyPrice,
+				PriceDescription:       v.PriceDescription,
 				LastUpdatedAt:          v.UpdatedAt,
 			}
 			pil = append(pil, r)
@@ -273,204 +122,10 @@ func (c *CostService) GetPriceInfo(param GetPriceInfoParam) (AllPriceInfoResult,
 }
 
 var (
-	units = map[string]bool{
-		"instance-hour":               true,
-		"hour":                        true,
-		"yrs":                         false,
-		"hrs":                         true,
-		"1 hour":                      true,
-		"virtual processor core-hour": true,
-	}
-)
-
-func parseUnit(p string) constant.PriceUnit {
-	ret := constant.PerHour
-
-	if p == "" {
-		return ret
-	}
-
-	a := strings.ToLower(p)
-
-	if v, ok := units[a]; v && ok {
-		return ret
-	}
-
-	return constant.PerYear
-}
-
-func splitMemory(input string) (string, constant.MemoryUnit) {
-	if input == "" {
-		return "", ""
-	}
-
-	var numberPart string
-	var unitPart string
-
-	for _, char := range input {
-		if unicode.IsDigit(char) || char == '.' {
-			numberPart += string(char)
-		} else {
-			unitPart += string(char)
-		}
-	}
-
-	number, err := strconv.ParseFloat(strings.TrimSpace(numberPart), 64)
-	if err != nil {
-		utils.LogErrorf("error while split memory : %s", err.Error())
-		return "", ""
-	}
-
-	num := fmt.Sprintf("%.0f", number)
-	unit := strings.ToLower(strings.TrimSpace(unitPart))
-
-	var memoryUnit constant.MemoryUnit
-	if unit == "" || unit == "gb" || unit == "gib" {
-		memoryUnit = constant.GIB
-	} else {
-		memoryUnit = constant.GIB
-	}
-	return num, memoryUnit
-}
-
-func parseCurrency(p string) constant.PriceCurrency {
-	if p == "" {
-		return constant.USD
-	}
-
-	switch strings.ToLower(p) {
-	case "usd":
-		return constant.USD
-	case "krw":
-		return constant.KRW
-	}
-
-	return constant.USD
-
-}
-
-func calculatePrice(p string, unit constant.PriceUnit) string {
-	if p == "" {
-		return "0.000000"
-	}
-
-	value, err := strconv.ParseFloat(strings.TrimSpace(p), 64)
-	if err != nil {
-		return "0.000000"
-	}
-
-	var monthlyCostStr string
-	if unit == constant.PerHour {
-
-		monthlyCost := value * 30 * 24
-		monthlyCostStr = fmt.Sprintf("%.6f", monthlyCost)
-	} else if unit == constant.PerYear {
-		monthlyCost := value
-		monthlyCostStr = fmt.Sprintf("%.6f", monthlyCost)
-	}
-
-	return monthlyCostStr
-}
-
-func generateFilterList(param GetPriceInfoParam) []spider.FilterReq {
-
-	providerName := strings.ToLower(param.ProviderName)
-
-	ret := []spider.FilterReq{
-		{
-			Key:   "instanceType",
-			Value: param.InstanceType,
-		},
-		{
-			Key:   "pricingPolicy",
-			Value: onDemandPricingPolicyMap[providerName],
-		},
-		{
-			Key:   "regionName",
-			Value: param.RegionName,
-		},
-	}
-
-	if strings.TrimSpace(param.ZoneName) != "" {
-		ret = append(ret, spider.FilterReq{
-			Key:   "zoneName",
-			Value: param.ZoneName,
-		})
-	}
-
-	if strings.TrimSpace(param.VCpu) != "" {
-		ret = append(ret, spider.FilterReq{
-			Key:   "vcpu",
-			Value: param.VCpu,
-		})
-	}
-
-	if strings.TrimSpace(param.Memory) != "" {
-		ret = append(ret, spider.FilterReq{
-			Key:   "memory",
-			Value: param.Memory,
-		})
-	}
-
-	if strings.TrimSpace(param.OsType) != "" {
-		ret = append(ret, spider.FilterReq{
-			Key:   "operatingSystem",
-			Value: param.OsType,
-		})
-	}
-
-	if strings.TrimSpace(param.Storage) != "" {
-		ret = append(ret, spider.FilterReq{
-			Key:   "storage",
-			Value: param.OsType,
-		})
-	}
-
-	return ret
-}
-
-func naChecker(originalValue string) string {
-	trimed := strings.TrimSpace(originalValue)
-	lower := strings.ToLower(trimed)
-
-	if lower == "na" || lower == "n/a" || lower == "0" {
-		return ""
-	}
-
-	return trimed
-}
-
-type UpdateCostInfoParam struct {
-	MigrationId       string
-	Provider          string // currently only aws
-	ConnectionName    string
-	StartDate         time.Time
-	EndDate           time.Time
-	CostResources     []CostResourceParam
-	AwsAdditionalInfo AwsAdditionalInfoParam
-}
-
-type CostResourceParam struct {
-	ResourceType constant.ResourceType
-	ResourceIds  []string
-}
-
-type AwsAdditionalInfoParam struct {
-	OwnerId string   `json:"ownerId"`
-	Regions []string `json:"regions"`
-}
-
-var (
 	ErrRequestResourceEmpty    = errors.New("cost request info is not enough")
 	ErrCostResultEmpty         = errors.New("cost information does not exist")
 	ErrCostResultFormatInvalid = errors.New("cost result does not matching with interface")
 )
-
-type UpdateCostInfoResult struct {
-	FetchedDataCount  int64
-	UpdatedDataCount  int64
-	InsertedDataCount int64
-}
 
 func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
@@ -478,7 +133,7 @@ func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoR
 
 	var updateCostInfoResult UpdateCostInfoResult
 
-	r, err := c.costCollector.GetCostInfo(ctx, param)
+	r, err := c.costCollector.GetCostInfos(ctx, param)
 	if err != nil {
 		return updateCostInfoResult, err
 	}
@@ -502,28 +157,6 @@ func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoR
 	updateCostInfoResult.InsertedDataCount = insertedCount
 
 	return updateCostInfoResult, nil
-}
-
-type GetCostInfoParam struct {
-	StartDate           time.Time
-	EndDate             time.Time
-	MigrationIds        []string
-	Providers           []string
-	ResourceTypes       []constant.ResourceType
-	ResourceIds         []string
-	CostAggregationType constant.CostAggregationType
-	DateOrder           constant.OrderType
-	ResourceTypeOrder   constant.OrderType
-}
-
-type GetCostInfoResult struct {
-	Provider         string    `json:"provider"`
-	ResourceType     string    `json:"resourceType"`
-	Category         string    `json:"category"`
-	ActualResourceId string    `json:"resourceId"`
-	Unit             string    `json:"unit"`
-	Date             time.Time `json:"date"`
-	TotalCost        float64   `json:"totalCost"`
 }
 
 func (c *CostService) GetCostInfos(param GetCostInfoParam) ([]GetCostInfoResult, error) {

--- a/internal/core/cost/service.go
+++ b/internal/core/cost/service.go
@@ -137,6 +137,7 @@ func (c *CostService) UpdateCostInfo(param UpdateCostInfoParam) (UpdateCostInfoR
 		updatedCount += u
 		insertedCount += i
 	}
+	utils.LogInfof("updated count: %d; inserted count : %d", updatedCount, insertedCount)
 
 	updateCostInfoResult.UpdatedDataCount = updatedCount
 	updateCostInfoResult.InsertedDataCount = insertedCount


### PR DESCRIPTION
## 작업내용
- 하나의 api 에서 제공하던 조회와 업데이트를 분리
- 분리된 파일로 서비스 계층의 dto 제공
- price 관련 price collector 생성
- 관련된 api swagger 문서에 대한 업데이트

## 관련 이슈 및 고려 사항
- update 시 connection 정보 제공을 위해 provider 와 region 은 반드시 넘겨야함
  - provider-region 의 format 으로 생성
- provider 에 따른 instance type 과 fetch 방식에 대한 고려를 응답 시간에 따라 적절하게 개선 필요
  - 전체 instance type 없이 region 으로 조회 결과 - 리전에 따라 다르지만 대략적인 시간
    - azure - 10초
    - alibaba - 약 1분
    - aws - 약 2분
    - gcp - 5분 이상 -> instance type 이 지정되는 경우 15초 미만
    - ibm - 1분
    - tencent - 10초
- price update 의 경우 7일 이내의 데이터가 없으면 다시 업데이트
  - 이 과정에서 provider, region 그리고 instance type(존재하는 경우)를 이용해 필터링
  - instance type 이 aaa 와 같이 존재하지 않는 인스턴스 타입을 넣는 경우 해당 데이터가 db 에 존재하지 않기 때문에 price collector 를 통한 가격 조회
  - **동일한 데이터 (7일 이내의 price) 가 중복되어 database 에 쌓임**
  - instance type 검증 등과 같은 전처리 과정의 필요성 대두
 