### PR TITLE
ci: AI 직접 commit signoff 및 co-authored-by 기록 차단 워크플로우 추가

### DIFF
--- a/.github/workflows/no-ai-trace.yml
+++ b/.github/workflows/no-ai-trace.yml
@@ -1,0 +1,145 @@
+# ------------------------------------------------------------
+# Policy enforcement for open-source contributions: block AI direct commit signoff and co-authored-by attribution from being merged.
+#
+# In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, AI direct commit signoff and co-authored-by records are prohibited.
+#
+# Canonical source: https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml
+# Reference policy: https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md
+# Local path in target repo: .github/workflows/no-ai-trace.yml
+# ------------------------------------------------------------
+
+name: AI Direct Commit Attribution Check
+
+on:
+  pull_request:
+    branches: [main, develop, master]
+  push:
+    branches: [main, develop, master]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  block-ai-attribution:
+    name: Block AI direct commit signoff and co-authored-by
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Determine commit range to scan
+        id: range
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> $GITHUB_OUTPUT
+            echo "to=${{ github.event.pull_request.head.sha }}" >> $GITHUB_OUTPUT
+          else
+            BEFORE="${{ github.event.before }}"
+            if [ "$BEFORE" = "0000000000000000000000000000000000000000" ] || [ -z "$BEFORE" ]; then
+              echo "from=${{ github.sha }}~1" >> $GITHUB_OUTPUT
+            else
+              echo "from=$BEFORE" >> $GITHUB_OUTPUT
+            fi
+            echo "to=${{ github.sha }}" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Scan commits for AI direct attribution
+        id: scan
+        run: |
+          FROM="${{ steps.range.outputs.from }}"
+          TO="${{ steps.range.outputs.to }}"
+
+          # Patterns matched against commit message body and trailers
+          BODY_PATTERNS='Co-Authored-By:.*[Cc]laude|Co-Authored-By:.*[Aa]nthropic|Co-Authored-By:.*[Cc]opilot|Generated-By:.*[Cc]laude|Generated-By:.*[Cc]ode|Assisted-By|Co-Developed-By|noreply@anthropic\.com'
+
+          # Patterns matched against author and committer email
+          EMAIL_PATTERNS='@anthropic\.com|copilot-swe-agent'
+
+          FOUND=""
+          for sha in $(git rev-list "$FROM..$TO" 2>/dev/null); do
+            SUBJECT=$(git log -1 --pretty='%s' "$sha")
+            BODY=$(git log -1 --pretty='%B' "$sha")
+            AUTHOR_EMAIL=$(git log -1 --pretty='%ae' "$sha")
+            COMMITTER_EMAIL=$(git log -1 --pretty='%ce' "$sha")
+
+            BAD=""
+            HIT=$(echo "$BODY" | grep -iE "$BODY_PATTERNS" | head -3)
+            if [ -n "$HIT" ]; then
+              BAD="$BAD"$'\n'"  - body/trailer match:"$'\n'"$(echo "$HIT" | sed 's/^/      /')"
+            fi
+
+            for email in "$AUTHOR_EMAIL" "$COMMITTER_EMAIL"; do
+              if echo "$email" | grep -iqE "$EMAIL_PATTERNS"; then
+                BAD="$BAD"$'\n'"  - AI tool email match: $email"
+              fi
+            done
+
+            if [ -n "$BAD" ]; then
+              FOUND="$FOUND"$'\n\n'"### $sha"$'\n'"  subject: $SUBJECT$BAD"
+            fi
+          done
+
+          if [ -n "$FOUND" ]; then
+            {
+              echo "found=true"
+              echo "details<<EOF"
+              echo "$FOUND"
+              echo "EOF"
+            } >> $GITHUB_OUTPUT
+
+            echo "::error::AI direct commit signoff or co-authored-by attribution detected. See logs and PR comment for details."
+            echo "$FOUND"
+            exit 1
+          fi
+
+          echo "found=false" >> $GITHUB_OUTPUT
+          echo "OK: no AI direct commit signoff or co-authored-by attribution found."
+
+      - name: Post failure comment on PR
+        if: failure() && github.event_name == 'pull_request'
+        uses: actions/github-script@v9
+        with:
+          script: |
+            const details = `${{ steps.scan.outputs.details }}`;
+            const body = [
+              '## AI Direct Commit Attribution Blocked',
+              '',
+              'This pull request cannot be merged because it contains commits with AI tool attribution (Claude, Anthropic, GitHub Copilot, etc.) in commit message trailers (for example `Co-Authored-By`, `Signed-off-by`, `Generated-By`) or in the author/committer email.',
+              '',
+              '### Why this is blocked',
+              '',
+              'In open-source contributions, the human author is expected to create commits and open pull requests. Under current open-source license frameworks (DCO, Sign-off, CLA, etc.) AI-attributed commits may have unclear implications. Following the community proposal from 2026-05-08, until the project policy is finalized, **AI direct commit signoff and co-authored-by records are prohibited** in this repository.',
+              '',
+              '<details><summary>Matched commits</summary>',
+              '',
+              '```',
+              details,
+              '```',
+              '',
+              '</details>',
+              '',
+              '### How to fix',
+              '',
+              'Most recent commit only - strip the attribution trailers:',
+              '```bash',
+              'git commit --amend --message="$(git log -1 --pretty=\'%s%n%n%b\' | grep -vE \'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:\')"',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'Multiple commits - use interactive rebase:',
+              '```bash',
+              'git rebase -i HEAD~5',
+              '# Mark each commit as `reword` and remove the trailer lines in the editor',
+              'git push --force-with-lease',
+              '```',
+              '',
+              'The check will re-run automatically after the force-push, and the merge can proceed once the AI direct commit signoff and co-authored-by records are removed. Repository administrators may also enforce this check via Branch Protection rules.'
+            ].join('\n');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });


### PR DESCRIPTION
## 배경

본 PR은 공지 메일의 "AI 직접 commit signoff 및 co-authored-by 기록 금지" 제안처럼 AI 관련 정책이 확정되기 전까지는 AI 직접 commit signoff 및 co-authored-by 기록을 Merge 단계에서 차단하기 위해 commit history에 AI 도구(Claude, Anthropic, GitHub Copilot 등)의 개입을 방지할 수 있도록 PR 단계에서 자동으로 검증하는 GitHub Actions 워크플로우를 추가합니다.

## 동작 관련 참고 사항

- 파일: `.github/workflows/no-ai-trace.yml`
- 트리거: `main`, `develop`, `master` 브랜치 대상 push + pull_request
- 검사 대상: commit message·body·trailer + author/committer email
- 매치 패턴: `Co-Authored-By: Claude/Anthropic/Copilot`, `Generated-By: Claude/Code`, `Assisted-By`, `Co-Developed-By`, `noreply@anthropic.com`, `copilot-swe-agent[bot]` 등
- 매치 발생 시 status check 실패 + PR 코멘트 자동 생성 (정책 링크 + 수정 명령 안내)

## 머지 후 필수 후속 작업 (선택)

본 워크플로우는 *감지·알림*만 합니다. 실제 완벽한 머지 차단을 위해 `Settings → Branches`에서 각 보호 브랜치에 *별도로* Branch Protection rule을 추가해야 합니다.

- ☑ Require a pull request before merging
- ☑ Require status checks to pass before merging → 필수 status: `Block AI tool attribution`
- ☑ Require linear history
- ☑ Do not allow bypassing the above settings

## 개발자 가이드

작성 중인 commit에 AI 도구 trailer가 자동으로 추가되는 경우 다음 방법으로 끌 수 있습니다.

### GitHub Copilot

- VSCode/JetBrains: `Settings → GitHub Copilot → Commit message generation` 비활성화
- PR에서 Copilot 사용 시: `Settings → Co-author with Copilot in pull requests` 비활성화

### Cursor / Windsurf

- Settings에서 AI 어시스턴트 commit attribution 옵션 비활성화 (메뉴 명칭은 버전마다 다름)

### git 전역 안전장치 (도구 무관)

```bash
git config --global commit.cleanup strip
```

### 이미 push한 commit에서 AI 직접 commit signoff 및 co-authored-by 기록을 제거하는 방법

가장 최근 commit 1건만:

```bash
git commit --amend --message="$(git log -1 --pretty='%s%n%n%b' | grep -vE 'Co-Authored-By:|Generated-By:|Assisted-By:|Co-Developed-By:')"
git push --force-with-lease
```

여러 건 일괄 처리 (interactive rebase):

```bash
git rebase -i HEAD~5
# 각 commit을 `reword`로 설정 → 편집기에서 trailer 라인 삭제
git push --force-with-lease
```

수정 push 후 Actions가 자동으로 재실행됩니다.

---

## MZC 관련 정책

- 핵심 원칙: cmig-workflow 본 저장소 외 모든 C-Mig 관련 git 저장소에 *AI가 개입하지 않는다*.
- 정책 문서: [POLICY-AI-TRACE-GUARD](https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-AI-TRACE-GUARD.md)
- 정책 신설일: 2026-06-10
- cmig-workflow Task: 001_AI흔적-MZC-fork정리
- JIRA: BAR-860

표준 yaml 원본·갱신은 [cmig-workflow/conf/workflow-templates/no-ai-trace.yml](https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/no-ai-trace.yml)에서 관리합니다. 본 원본이 갱신되면 본 저장소의 파일도 원본에서 다시 동기화합니다.
