### PR TITLE
ci: add security gate workflow (secret/SAST/dependency scan)

### DIFF
--- a/.github/workflows/security-gate.yml
+++ b/.github/workflows/security-gate.yml
@@ -1,0 +1,109 @@
+# ------------------------------------------------------------
+# Security Gate — PR 시점 보안 점검 (시크릿·Go SAST·Go 취약점·의존성/Dockerfile).
+#
+# 표준 원본: https://github.com/MZC-CSC/cmig-workflow/blob/main/conf/workflow-templates/security-gate.yml
+# 정책: https://github.com/MZC-CSC/cmig-workflow/blob/main/POLICY-SECURITY.md
+#
+# 도입 단계(Phase A): 시크릿 게이트만 차단(현재 실제 시크릿 0건이라 안전), 나머지(gosec·
+# govulncheck·Trivy)는 경고 모드(continue-on-error)로 보고만 한다. 기준선 정리 후
+# Phase B에서 신규분 차단으로 승격한다(cmig-workflow GUIDE-보안게이트-기준선및롤아웃).
+#
+# - 스캐너는 바이너리로 직접 설치(액션 공급망 의존 축소), first-party 액션은 commit SHA pin.
+# - 컨테이너 이미지 CVE 스캔은 소스 CI가 아니라 이미지 빌드 파이프라인(onecloud-ci)에서 수행.
+# ------------------------------------------------------------
+
+name: Security Gate
+
+on:
+  pull_request:
+    branches: [develop, main]
+  push:
+    branches: [develop, main]
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  GITLEAKS_VERSION: "8.21.2"
+  TRIVY_VERSION: "0.71.2"
+
+jobs:
+  # 시크릿 — 차단(Phase A). 실제 시크릿 0건 기준선.
+  secret-scan:
+    name: Secret scan (gitleaks)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+      - name: Install gitleaks
+        run: |
+          curl -fsSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o gitleaks.tgz
+          tar -xzf gitleaks.tgz gitleaks
+      - name: Run gitleaks (filesystem, redacted) — blocking
+        run: |
+          ./gitleaks dir . --report-format sarif --report-path gitleaks.sarif --redact --exit-code 1
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: gitleaks.sarif
+          category: gitleaks
+
+  # Go SAST + 취약점 — 경고(Phase A). 기준선(gosec ~16·govulncheck 45) 정리 후 신규분 차단으로 승격.
+  go-security:
+    name: Go SAST + vuln (gosec, govulncheck)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
+        with:
+          go-version-file: go.mod
+      - name: gosec (SAST, 경고)
+        continue-on-error: true
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@v2.21.4
+          gosec -no-fail -fmt sarif -out gosec.sarif ./...
+      - name: Upload gosec SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: gosec.sarif
+          category: gosec
+      - name: govulncheck (도달 가능 취약점, 경고)
+        continue-on-error: true
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@latest
+          govulncheck ./... | tee govulncheck.txt || true
+      - name: Summarize
+        if: always()
+        run: |
+          GOSEC=$(jq '[.runs[].results[]] | length' gosec.sarif 2>/dev/null || echo "?")
+          VULN=$(grep -c "Vulnerability #" govulncheck.txt 2>/dev/null || echo "0")
+          {
+            echo "### Security Gate — Go 정적분석/취약점 (경고)"
+            echo "- gosec 발견: ${GOSEC} 건 / govulncheck 도달 가능 취약점: ${VULN} 건"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # 의존성/Dockerfile — 경고(Phase A). 컨테이너 이미지 레이어 CVE는 빌드 파이프라인(onecloud-ci)에서.
+  trivy:
+    name: Dependencies + Dockerfile (Trivy fs)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - name: Install Trivy
+        run: |
+          curl -fsSL "https://github.com/aquasecurity/trivy/releases/download/v${TRIVY_VERSION}/trivy_${TRIVY_VERSION}_Linux-64bit.tar.gz" -o trivy.tgz
+          tar -xzf trivy.tgz trivy
+          sudo mv trivy /usr/local/bin/
+      - name: Trivy filesystem (의존성·Dockerfile·시크릿, 경고)
+        continue-on-error: true
+        run: |
+          trivy fs --scanners vuln,misconfig,secret --format sarif --output trivy-fs.sarif --exit-code 0 .
+      - name: Upload Trivy fs SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@dd903d2e4f5405488e5ef1422510ee31c8b32357 # v3
+        with:
+          sarif_file: trivy-fs.sarif
+          category: trivy-fs


### PR DESCRIPTION
## 개요
PR 시점 보안 점검 워크플로우(`.github/workflows/security-gate.yml`)를 추가합니다. 사내 보안 표준(코드·이미지 보안성 확보)을 개발 흐름에 통합하는 첫 적용입니다.

## 무엇을 하나
- **시크릿 스캔(gitleaks)** — *차단*. 변경 파일에서 키·토큰 유입을 막습니다(현재 저장소 실제 시크릿 0건 기준).
- **Go 정적분석(gosec)·취약점(govulncheck)** — *경고*(보고만). 기존 실제 findings가 있어 1단계는 경고로 둡니다.
- **의존성/Dockerfile(Trivy fs)** — *경고*. 컨테이너 이미지 레이어 CVE는 이미지 빌드 파이프라인에서 별도 점검합니다.
- 결과는 GitHub **Security 탭(code scanning)** + 실행 요약에 표시됩니다.

## 도입 단계 (Phase A)
무작정 전부 차단하면 기존 실제 findings 때문에 CI가 막히므로, **시크릿만 차단·나머지는 경고**로 시작합니다. 기준선 정리 후 신규분 차단으로 승격하고, 그때 Branch Protection의 required check로 등록합니다(팀 협의).

## 안전성
- 새 파일 1개 추가라 기존 소스와 충돌 없습니다.
- 스캐너는 바이너리로 직접 설치하고, 외부 액션은 commit SHA로 고정했습니다(공급망 사고 대비).
- 경고 모드라 머지/빌드를 막지 않습니다(시크릿 발견 시에만 실패 표시).

## 검증
의도적 결함을 심은 전용 브랜치로 게이트 발화를 확인했습니다(시크릿·SAST·의존성·Dockerfile·이미지 모두 검출). 자세한 검증 결과는 아래 결과서를 참고하세요.

---
- [BAR-1344](https://mzdevs.atlassian.net/browse/BAR-1344) CI/CD 보안 게이트 통합
- 검증 결과서: https://mzdevs.atlassian.net/wiki/x/UYBORQE