### PR TITLE
feat(readyz): enforce dependency auth and add startup fail-fast check

### DIFF
--- a/api/docs.go
+++ b/api/docs.go
@@ -1550,7 +1550,7 @@ const docTemplate = `{
         },
         "/readyz": {
             "get": {
-                "description": "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.",
+                "description": "Returns CM-Ant server readiness including DB and outbound\ndependency (cb-spider, cb-tumblebug) reachability and\nauthentication. Per STANDARD-READYZ pattern B, the response\nbody always carries per-dependency status; the HTTP status is\n200 when every dependency is reachable and authenticated, and\n503 otherwise. Results are cached briefly to limit outbound\ncall rate; see STANDARD-READYZ for details.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1560,25 +1560,19 @@ const docTemplate = `{
                 "tags": [
                     "[Server Health]"
                 ],
-                "summary": "Check CB-Ant API server readiness",
+                "summary": "Check CM-Ant API server readiness",
                 "operationId": "AntServerReadiness",
                 "responses": {
                     "200": {
-                        "description": "CM-Ant API server is ready",
+                        "description": "CM-Ant is ready (all dependencies healthy)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     },
                     "503": {
-                        "description": "CB-Ant API server is not ready",
+                        "description": "CM-Ant is not ready (see dependencies for the failing component)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     }
                 }
@@ -1946,6 +1940,40 @@ const docTemplate = `{
                 }
             }
         },
+        "app.DepResult": {
+            "type": "object",
+            "properties": {
+                "db": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "spider": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "tumblebug": {
+                    "$ref": "#/definitions/app.DepStatus"
+                }
+            }
+        },
+        "app.DepStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "lastCheck": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -2159,6 +2187,23 @@ const docTemplate = `{
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "app.readyzResponse": {
+            "type": "object",
+            "properties": {
+                "dependencies": {
+                    "$ref": "#/definitions/app.DepResult"
+                },
+                "initialized": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },
@@ -3025,7 +3070,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.4.0",
+	Version:          "0.5.2",
 	Host:             "",
 	BasePath:         "/ant",
 	Schemes:          []string{},

--- a/api/docs.go
+++ b/api/docs.go
@@ -3070,7 +3070,7 @@ const docTemplate = `{
 
 // SwaggerInfo holds exported Swagger Info so clients can modify it
 var SwaggerInfo = &swag.Spec{
-	Version:          "0.5.2",
+	Version:          "0.6.0",
 	Host:             "",
 	BasePath:         "/ant",
 	Schemes:          []string{},

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,7 +4,7 @@
         "description": "CM-ANT REST API swagger document.",
         "title": "CM-ANT REST API",
         "contact": {},
-        "version": "0.5.2"
+        "version": "0.6.0"
     },
     "basePath": "/ant",
     "paths": {

--- a/api/swagger.json
+++ b/api/swagger.json
@@ -4,7 +4,7 @@
         "description": "CM-ANT REST API swagger document.",
         "title": "CM-ANT REST API",
         "contact": {},
-        "version": "0.4.0"
+        "version": "0.5.2"
     },
     "basePath": "/ant",
     "paths": {
@@ -1543,7 +1543,7 @@
         },
         "/readyz": {
             "get": {
-                "description": "This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.",
+                "description": "Returns CM-Ant server readiness including DB and outbound\ndependency (cb-spider, cb-tumblebug) reachability and\nauthentication. Per STANDARD-READYZ pattern B, the response\nbody always carries per-dependency status; the HTTP status is\n200 when every dependency is reachable and authenticated, and\n503 otherwise. Results are cached briefly to limit outbound\ncall rate; see STANDARD-READYZ for details.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1553,25 +1553,19 @@
                 "tags": [
                     "[Server Health]"
                 ],
-                "summary": "Check CB-Ant API server readiness",
+                "summary": "Check CM-Ant API server readiness",
                 "operationId": "AntServerReadiness",
                 "responses": {
                     "200": {
-                        "description": "CM-Ant API server is ready",
+                        "description": "CM-Ant is ready (all dependencies healthy)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     },
                     "503": {
-                        "description": "CB-Ant API server is not ready",
+                        "description": "CM-Ant is not ready (see dependencies for the failing component)",
                         "schema": {
-                            "type": "object",
-                            "additionalProperties": {
-                                "type": "string"
-                            }
+                            "$ref": "#/definitions/app.readyzResponse"
                         }
                     }
                 }
@@ -1939,6 +1933,40 @@
                 }
             }
         },
+        "app.DepResult": {
+            "type": "object",
+            "properties": {
+                "db": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "ready": {
+                    "type": "boolean"
+                },
+                "spider": {
+                    "$ref": "#/definitions/app.DepStatus"
+                },
+                "tumblebug": {
+                    "$ref": "#/definitions/app.DepStatus"
+                }
+            }
+        },
+        "app.DepStatus": {
+            "type": "object",
+            "properties": {
+                "authenticated": {
+                    "type": "boolean"
+                },
+                "error": {
+                    "type": "string"
+                },
+                "lastCheck": {
+                    "type": "string"
+                },
+                "reachable": {
+                    "type": "boolean"
+                }
+            }
+        },
         "app.InstallLoadGeneratorReq": {
             "type": "object",
             "properties": {
@@ -2152,6 +2180,23 @@
                 },
                 "nsId": {
                     "type": "string"
+                }
+            }
+        },
+        "app.readyzResponse": {
+            "type": "object",
+            "properties": {
+                "dependencies": {
+                    "$ref": "#/definitions/app.DepResult"
+                },
+                "initialized": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
+                },
+                "ready": {
+                    "type": "boolean"
                 }
             }
         },

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -993,7 +993,7 @@ info:
   contact: {}
   description: CM-ANT REST API swagger document.
   title: CM-ANT REST API
-  version: 0.5.2
+  version: 0.6.0
 paths:
   /api/v1/cost/estimate:
     get:

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -233,6 +233,28 @@ definitions:
       resourceType:
         $ref: '#/definitions/constant.ResourceType'
     type: object
+  app.DepResult:
+    properties:
+      db:
+        $ref: '#/definitions/app.DepStatus'
+      ready:
+        type: boolean
+      spider:
+        $ref: '#/definitions/app.DepStatus'
+      tumblebug:
+        $ref: '#/definitions/app.DepStatus'
+    type: object
+  app.DepStatus:
+    properties:
+      authenticated:
+        type: boolean
+      error:
+        type: string
+      lastCheck:
+        type: string
+      reachable:
+        type: boolean
+    type: object
   app.InstallLoadGeneratorReq:
     properties:
       installLocation:
@@ -378,6 +400,17 @@ definitions:
         type: string
       nsId:
         type: string
+    type: object
+  app.readyzResponse:
+    properties:
+      dependencies:
+        $ref: '#/definitions/app.DepResult'
+      initialized:
+        type: boolean
+      message:
+        type: string
+      ready:
+        type: boolean
     type: object
   constant.ExecutionStatus:
     enum:
@@ -960,7 +993,7 @@ info:
   contact: {}
   description: CM-ANT REST API swagger document.
   title: CM-ANT REST API
-  version: 0.4.0
+  version: 0.5.2
 paths:
   /api/v1/cost/estimate:
     get:
@@ -2004,26 +2037,27 @@ paths:
     get:
       consumes:
       - application/json
-      description: This endpoint checks if the CB-Ant API server is ready by verifying
-        the status of both the load service and the cost service. If either service
-        is unavailable, it returns a 503 status indicating the server is not ready.
+      description: |-
+        Returns CM-Ant server readiness including DB and outbound
+        dependency (cb-spider, cb-tumblebug) reachability and
+        authentication. Per STANDARD-READYZ pattern B, the response
+        body always carries per-dependency status; the HTTP status is
+        200 when every dependency is reachable and authenticated, and
+        503 otherwise. Results are cached briefly to limit outbound
+        call rate; see STANDARD-READYZ for details.
       operationId: AntServerReadiness
       produces:
       - application/json
       responses:
         "200":
-          description: CM-Ant API server is ready
+          description: CM-Ant is ready (all dependencies healthy)
           schema:
-            additionalProperties:
-              type: string
-            type: object
+            $ref: '#/definitions/app.readyzResponse'
         "503":
-          description: CB-Ant API server is not ready
+          description: CM-Ant is not ready (see dependencies for the failing component)
           schema:
-            additionalProperties:
-              type: string
-            type: object
-      summary: Check CB-Ant API server readiness
+            $ref: '#/definitions/app.readyzResponse'
+      summary: Check CM-Ant API server readiness
       tags:
       - '[Server Health]'
 swagger: "2.0"

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -21,7 +21,7 @@ import (
 // InitRouter initializes the routing for CM-ANT API server.
 
 // @title CM-ANT REST API
-// @version 0.4.0
+// @version 0.5.2
 // @description CM-ANT REST API swagger document.
 // @basePath /ant
 

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -21,7 +21,7 @@ import (
 // InitRouter initializes the routing for CM-ANT API server.
 
 // @title CM-ANT REST API
-// @version 0.5.2
+// @version 0.6.0
 // @description CM-ANT REST API swagger document.
 // @basePath /ant
 

--- a/cmd/cm-ant/main.go
+++ b/cmd/cm-ant/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 
 	"os"
@@ -86,6 +87,17 @@ func main() {
 	if err != nil {
 		log.Fatal().Msgf("CM-Ant server creation error: %v", err)
 	}
+
+	// Fail-fast dependency check before accepting traffic. Per STANDARD-READYZ
+	// (cmig-workflow c-mig-common/design/07-DESIGN/STANDARD-READYZ.md §6.2),
+	// the container should not enter a "healthy but non-functional" state when
+	// DB, cb-spider, or cb-tumblebug are unreachable or misconfigured.
+	startupCtx, startupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if derr := s.CheckStartupDependencies(startupCtx); derr != nil {
+		startupCancel()
+		log.Fatal().Msgf("CM-Ant startup dependency check failed: %v", derr)
+	}
+	startupCancel()
 
 	// Initialize the router for the CM-Ant server
 	err = s.InitRouter()

--- a/internal/app/common_handler.go
+++ b/internal/app/common_handler.go
@@ -6,32 +6,47 @@ import (
 	"github.com/labstack/echo/v4"
 )
 
+// readyzResponse is the response shape for GET /ant/readyz. It follows pattern
+// B of c-mig-common STANDARD-READYZ (cmig-workflow
+// c-mig-common/design/07-DESIGN/STANDARD-READYZ.md): a structured body that
+// callers can inspect for per-dependency reachable/authenticated state in
+// addition to the HTTP status code. cm-ant itself has no separate
+// initialization step, so Initialized is always true when Ready is true.
+type readyzResponse struct {
+	Ready        bool       `json:"ready"`
+	Initialized  bool       `json:"initialized"`
+	Message      string     `json:"message"`
+	Dependencies *DepResult `json:"dependencies"`
+}
+
 // @Id AntServerReadiness
-// @Summary Check CB-Ant API server readiness
-// @Description This endpoint checks if the CB-Ant API server is ready by verifying the status of both the load service and the cost service. If either service is unavailable, it returns a 503 status indicating the server is not ready.
+// @Summary Check CM-Ant API server readiness
+// @Description Returns CM-Ant server readiness including DB and outbound
+// @Description dependency (cb-spider, cb-tumblebug) reachability and
+// @Description authentication. Per STANDARD-READYZ pattern B, the response
+// @Description body always carries per-dependency status; the HTTP status is
+// @Description 200 when every dependency is reachable and authenticated, and
+// @Description 503 otherwise. Results are cached briefly to limit outbound
+// @Description call rate; see STANDARD-READYZ for details.
 // @Tags [Server Health]
 // @Accept json
 // @Produce json
-// @Success 200 {object} map[string]string "CM-Ant API server is ready"
-// @Failure 503 {object} map[string]string "CB-Ant API server is not ready"
+// @Success 200 {object} readyzResponse "CM-Ant is ready (all dependencies healthy)"
+// @Failure 503 {object} readyzResponse "CM-Ant is not ready (see dependencies for the failing component)"
 // @Router /readyz [get]
 func (s *AntServer) readyz(c echo.Context) error {
-	err := s.services.loadService.Readyz()
-	if err != nil {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, map[string]string{
-			"message": "CM-Ant API server is not ready",
-		})
+	res := s.getDependencyStatus(c.Request().Context())
+
+	body := readyzResponse{
+		Ready:        res.Ready,
+		Initialized:  res.Ready,
+		Dependencies: res,
 	}
 
-	err = s.services.costService.Readyz()
-
-	if err != nil {
-		return echo.NewHTTPError(http.StatusServiceUnavailable, map[string]string{
-			"message": "CM-Ant API server is not ready",
-		})
+	if !res.Ready {
+		body.Message = "CM-Ant is not ready — see dependencies for the failing component"
+		return c.JSON(http.StatusServiceUnavailable, body)
 	}
-
-	return c.JSON(http.StatusOK, map[string]string{
-		"message": "CM-Ant API server is ready",
-	})
+	body.Message = "CM-Ant is ready"
+	return c.JSON(http.StatusOK, body)
 }

--- a/internal/app/common_handler.go
+++ b/internal/app/common_handler.go
@@ -44,7 +44,7 @@ func (s *AntServer) readyz(c echo.Context) error {
 	}
 
 	if !res.Ready {
-		body.Message = "CM-Ant is not ready — see dependencies for the failing component"
+		body.Message = "CM-Ant is not ready - see dependencies for the failing component"
 		return c.JSON(http.StatusServiceUnavailable, body)
 	}
 	body.Message = "CM-Ant is ready"

--- a/internal/app/dependency_check.go
+++ b/internal/app/dependency_check.go
@@ -1,0 +1,187 @@
+package app
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/spider"
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug"
+	"gorm.io/gorm"
+)
+
+// depCacheTTL controls how long the /ant/readyz handler reuses a previous
+// dependency check result before re-checking. Per STANDARD-READYZ §8, this
+// limits outbound dependency call rate to at most one full check per TTL.
+// Startup uses CheckStartupDependencies which bypasses the cache.
+const depCacheTTL = 30 * time.Second
+
+// DepStatus captures the result of probing a single dependency.
+type DepStatus struct {
+	Reachable     bool      `json:"reachable"`
+	Authenticated bool      `json:"authenticated"`
+	LastCheck     time.Time `json:"lastCheck"`
+	Error         string    `json:"error,omitempty"`
+}
+
+// DepResult captures the result of probing all dependencies cm-ant needs to
+// service requests. Per STANDARD-READYZ §3, a dependency is considered fully
+// healthy only when both Reachable and Authenticated are true (cb-tumblebug
+// also requires Ready==true && Initialized==true; that check happens inside
+// tumblebug_client.ReadyzWithContext).
+type DepResult struct {
+	Ready     bool      `json:"ready"`
+	DB        DepStatus `json:"db"`
+	Spider    DepStatus `json:"spider"`
+	Tumblebug DepStatus `json:"tumblebug"`
+}
+
+type depCache struct {
+	mu      sync.Mutex
+	last    *DepResult
+	lastSet time.Time
+}
+
+// checkDependencies runs the full STANDARD-READYZ §3 check sequence:
+//  1. DB connectivity (gorm handle + Ping)
+//  2. cb-spider /readyz reachability
+//  3. cb-spider /cloudos with Basic Auth (auth enforcement)
+//  4. cb-tumblebug /readyz body inspection (Ready && Initialized)
+//  5. cb-tumblebug /cloudInfo with Basic Auth (auth enforcement)
+//
+// It always probes live; callers wanting the cached result should use
+// getDependencyStatus.
+func (s *AntServer) checkDependencies(ctx context.Context) *DepResult {
+	now := time.Now()
+	res := &DepResult{}
+
+	// 1. DB
+	res.DB = probeDB(ctx, s.db, now)
+
+	// 2/3. cb-spider
+	res.Spider = probeSpider(ctx, s.spiderClient, now)
+
+	// 4/5. cb-tumblebug
+	res.Tumblebug = probeTumblebug(ctx, s.tumblebugClient, now)
+
+	res.Ready = res.DB.Reachable && res.DB.Authenticated &&
+		res.Spider.Reachable && res.Spider.Authenticated &&
+		res.Tumblebug.Reachable && res.Tumblebug.Authenticated
+	return res
+}
+
+func probeDB(ctx context.Context, db *gorm.DB, now time.Time) DepStatus {
+	if db == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cm-ant DB connection is nil. Check ANT_DB_HOST/USER/PASSWORD and DB connectivity"}
+	}
+	sqlDB, err := db.DB()
+	if err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cm-ant DB handle 획득 실패: %v. Check DB driver/configuration", err)}
+	}
+	if err := sqlDB.PingContext(ctx); err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cm-ant DB ping 실패: %v. Check ANT_DB_HOST/USER/PASSWORD/network", err)}
+	}
+	// DB connectivity == authentication for DB (creds are part of the conn).
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+func probeSpider(ctx context.Context, c *spider.SpiderClient, now time.Time) DepStatus {
+	if c == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cb-spider client is nil"}
+	}
+	endpoint := c.Endpoint()
+	if err := c.ReadyzWithContext(ctx); err != nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-spider 미응답 (host=%s): %v. Check cb-spider 컨테이너 상태·network", endpoint, err)}
+	}
+	if err := c.AuthCheckWithContext(ctx); err != nil {
+		if errors.Is(err, spider.ErrUnauthorized) {
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-spider 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_SPIDER_USERNAME/ANT_SPIDER_PASSWORD 환경변수 또는 config Spider.Username/Password 확인 필요", endpoint)}
+		}
+		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-spider 인증 확인 호출 오류 (host=%s, GET /spider/cloudos): %v", endpoint, err)}
+	}
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+func probeTumblebug(ctx context.Context, c *tumblebug.TumblebugClient, now time.Time) DepStatus {
+	if c == nil {
+		return DepStatus{Reachable: false, LastCheck: now,
+			Error: "cb-tumblebug client is nil"}
+	}
+	endpoint := c.Endpoint()
+	if err := c.ReadyzWithContext(ctx); err != nil {
+		switch {
+		case errors.Is(err, tumblebug.ErrNotReady):
+			return DepStatus{Reachable: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+		case errors.Is(err, tumblebug.ErrNotInitialized):
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 초기화 미완료 (host=%s): %v. cb-tumblebug 초기화 절차 완료 필요", endpoint, err)}
+		default:
+			return DepStatus{Reachable: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+		}
+	}
+	if err := c.AuthCheckWithContext(ctx); err != nil {
+		if errors.Is(err, tumblebug.ErrUnauthorized) {
+			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+				Error: fmt.Sprintf("cb-tumblebug 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_TUMBLEBUG_USERNAME/ANT_TUMBLEBUG_PASSWORD 환경변수 또는 config Tumblebug.Username/Password 확인 필요", endpoint)}
+		}
+		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
+			Error: fmt.Sprintf("cb-tumblebug 인증 확인 호출 오류 (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
+	}
+	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
+}
+
+// getDependencyStatus returns the most recent dependency check result, running
+// a fresh probe only when the cache TTL has expired. Used by /ant/readyz.
+func (s *AntServer) getDependencyStatus(ctx context.Context) *DepResult {
+	s.depCache.mu.Lock()
+	defer s.depCache.mu.Unlock()
+
+	if s.depCache.last != nil && time.Since(s.depCache.lastSet) < depCacheTTL {
+		return s.depCache.last
+	}
+
+	s.depCache.last = s.checkDependencies(ctx)
+	s.depCache.lastSet = time.Now()
+	return s.depCache.last
+}
+
+// CheckStartupDependencies runs a fresh dependency probe (no cache) and returns
+// an aggregated error if any dependency is not fully healthy. Called from main
+// right after NewAntServer so the container exits with a clear message when a
+// dependency is missing or misconfigured, per STANDARD-READYZ §6.2.
+func (s *AntServer) CheckStartupDependencies(ctx context.Context) error {
+	res := s.checkDependencies(ctx)
+	if res.Ready {
+		// Seed the cache so the first /ant/readyz call after startup does not
+		// double-probe the dependencies that we just verified.
+		s.depCache.mu.Lock()
+		s.depCache.last = res
+		s.depCache.lastSet = time.Now()
+		s.depCache.mu.Unlock()
+		return nil
+	}
+
+	var msgs []string
+	if !res.DB.Reachable || !res.DB.Authenticated {
+		msgs = append(msgs, res.DB.Error)
+	}
+	if !res.Spider.Reachable || !res.Spider.Authenticated {
+		msgs = append(msgs, res.Spider.Error)
+	}
+	if !res.Tumblebug.Reachable || !res.Tumblebug.Authenticated {
+		msgs = append(msgs, res.Tumblebug.Error)
+	}
+	return errors.New(strings.Join(msgs, " | "))
+}

--- a/internal/app/dependency_check.go
+++ b/internal/app/dependency_check.go
@@ -81,11 +81,11 @@ func probeDB(ctx context.Context, db *gorm.DB, now time.Time) DepStatus {
 	sqlDB, err := db.DB()
 	if err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cm-ant DB handle 획득 실패: %v. Check DB driver/configuration", err)}
+			Error: fmt.Sprintf("failed to acquire cm-ant DB handle: %v. Check DB driver/configuration", err)}
 	}
 	if err := sqlDB.PingContext(ctx); err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cm-ant DB ping 실패: %v. Check ANT_DB_HOST/USER/PASSWORD/network", err)}
+			Error: fmt.Sprintf("cm-ant DB ping failed: %v. Check ANT_DB_HOST/USER/PASSWORD and network", err)}
 	}
 	// DB connectivity == authentication for DB (creds are part of the conn).
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
@@ -99,15 +99,15 @@ func probeSpider(ctx context.Context, c *spider.SpiderClient, now time.Time) Dep
 	endpoint := c.Endpoint()
 	if err := c.ReadyzWithContext(ctx); err != nil {
 		return DepStatus{Reachable: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-spider 미응답 (host=%s): %v. Check cb-spider 컨테이너 상태·network", endpoint, err)}
+			Error: fmt.Sprintf("cb-spider unreachable (host=%s): %v. Check cb-spider container state and network", endpoint, err)}
 	}
 	if err := c.AuthCheckWithContext(ctx); err != nil {
 		if errors.Is(err, spider.ErrUnauthorized) {
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-spider 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_SPIDER_USERNAME/ANT_SPIDER_PASSWORD 환경변수 또는 config Spider.Username/Password 확인 필요", endpoint)}
+				Error: fmt.Sprintf("cb-spider authentication failed (host=%s, HTTP 401). Verify ANT_SPIDER_USERNAME and ANT_SPIDER_PASSWORD env vars (or config Spider.Username/Password) on the cm-ant side", endpoint)}
 		}
 		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-spider 인증 확인 호출 오류 (host=%s, GET /spider/cloudos): %v", endpoint, err)}
+			Error: fmt.Sprintf("cb-spider auth check call error (host=%s, GET /spider/cloudos): %v", endpoint, err)}
 	}
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
 }
@@ -122,22 +122,22 @@ func probeTumblebug(ctx context.Context, c *tumblebug.TumblebugClient, now time.
 		switch {
 		case errors.Is(err, tumblebug.ErrNotReady):
 			return DepStatus{Reachable: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug unreachable (host=%s): %v. Check cb-tumblebug container state and network", endpoint, err)}
 		case errors.Is(err, tumblebug.ErrNotInitialized):
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 초기화 미완료 (host=%s): %v. cb-tumblebug 초기화 절차 완료 필요", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug not initialized (host=%s): %v. Complete cb-tumblebug initialization procedure", endpoint, err)}
 		default:
 			return DepStatus{Reachable: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 미응답 (host=%s): %v. Check cb-tumblebug 컨테이너 상태·network", endpoint, err)}
+				Error: fmt.Sprintf("cb-tumblebug unreachable (host=%s): %v. Check cb-tumblebug container state and network", endpoint, err)}
 		}
 	}
 	if err := c.AuthCheckWithContext(ctx); err != nil {
 		if errors.Is(err, tumblebug.ErrUnauthorized) {
 			return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-				Error: fmt.Sprintf("cb-tumblebug 인증 실패 (host=%s, HTTP 401). cm-ant 측 ANT_TUMBLEBUG_USERNAME/ANT_TUMBLEBUG_PASSWORD 환경변수 또는 config Tumblebug.Username/Password 확인 필요", endpoint)}
+				Error: fmt.Sprintf("cb-tumblebug authentication failed (host=%s, HTTP 401). Verify ANT_TUMBLEBUG_USERNAME and ANT_TUMBLEBUG_PASSWORD env vars (or config Tumblebug.Username/Password) on the cm-ant side", endpoint)}
 		}
 		return DepStatus{Reachable: true, Authenticated: false, LastCheck: now,
-			Error: fmt.Sprintf("cb-tumblebug 인증 확인 호출 오류 (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
+			Error: fmt.Sprintf("cb-tumblebug auth check call error (host=%s, GET /tumblebug/cloudInfo): %v", endpoint, err)}
 	}
 	return DepStatus{Reachable: true, Authenticated: true, LastCheck: now}
 }

--- a/internal/app/server.go
+++ b/internal/app/server.go
@@ -34,9 +34,19 @@ type antServices struct {
 // AntServer represents the server instance for the CM-Ant application.
 // It contains an Echo instance for handling HTTP requests
 // and multiple services for validating the core functionality of cloud migration.
+//
+// The spider/tumblebug clients and DB connection are also held directly so that
+// startup fail-fast and the /ant/readyz handler can share a single dependency
+// check function (see internal/app/dependency_check.go and STANDARD-READYZ in
+// cmig-workflow c-mig-common/design/07-DESIGN/STANDARD-READYZ.md).
 type AntServer struct {
-	e        *echo.Echo
-	services *antServices
+	e               *echo.Echo
+	services        *antServices
+	spiderClient    *spider.SpiderClient
+	tumblebugClient *tumblebug.TumblebugClient
+	db              *gorm.DB
+
+	depCache depCache
 }
 
 // NewAntServer initializes and returns a new instance of AntServer.
@@ -60,8 +70,11 @@ func NewAntServer() (*AntServer, error) {
 	services := initializeServices(repos, tumblebugClient, spiderClient, conn)
 
 	return &AntServer{
-		e:        e,
-		services: services,
+		e:               e,
+		services:        services,
+		spiderClient:    spiderClient,
+		tumblebugClient: tumblebugClient,
+		db:              conn,
 	}, nil
 }
 

--- a/internal/infra/outbound/spider/spider_client.go
+++ b/internal/infra/outbound/spider/spider_client.go
@@ -16,6 +16,7 @@ import (
 
 var (
 	ErrBadRequest          = errors.New("bad request")
+	ErrUnauthorized        = errors.New("unauthorized")
 	ErrNotFound            = errors.New("object not found")
 	ErrInternalServerError = errors.New("spider server has got error")
 )
@@ -54,6 +55,10 @@ func NewSpiderClient(client *http.Client) *SpiderClient {
 	}
 }
 
+func (s *SpiderClient) Endpoint() string {
+	return s.domain
+}
+
 func (s *SpiderClient) withUrl(endpoint string) string {
 	trimmedEndpoint := strings.TrimPrefix(endpoint, "/")
 	return fmt.Sprintf("%s/spider/%s", s.domain, trimmedEndpoint)
@@ -85,6 +90,8 @@ func (s *SpiderClient) requestWithContext(ctx context.Context, method, url strin
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, ErrNotFound
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			return nil, ErrInternalServerError
 		} else if resp.StatusCode == http.StatusBadRequest {
@@ -114,9 +121,25 @@ func (s *SpiderClient) ReadyzWithContext(ctx context.Context) error {
 	_, err := s.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
 
 	if err != nil {
-		log.Error().Msgf("error sending tumblebug readyz request; %v", err)
+		log.Error().Msgf("error sending cb-spider readyz request; %v", err)
 		return err
 	}
 
+	return nil
+}
+
+// AuthCheckWithContext calls a lightweight authenticated cb-spider endpoint
+// (GET /spider/cloudos) to verify Basic Auth credentials. Per STANDARD-READYZ
+// (c-mig-common/design/07-DESIGN/STANDARD-READYZ.md), the cb-spider /readyz
+// endpoint is on the auth-middleware skip list and therefore does not validate
+// credentials. /spider/cloudos is enforced and returns a small static list of
+// built-in cloud OS names, so it is unaffected by operator data.
+func (s *SpiderClient) AuthCheckWithContext(ctx context.Context) error {
+	url := s.withUrl("/cloudos")
+	_, err := s.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Error().Msgf("cb-spider auth check failed (GET /spider/cloudos); %v", err)
+		return err
+	}
 	return nil
 }

--- a/internal/infra/outbound/spider/spider_client_test.go
+++ b/internal/infra/outbound/spider/spider_client_test.go
@@ -1,0 +1,128 @@
+package spider
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestClient constructs a SpiderClient against the given httptest server.
+// Tests in the same package can set unexported fields directly.
+//
+// withUrl uses only the domain field, so we set domain to the full httptest
+// URL (scheme included). The host/port fields mirror the parsed URL for
+// completeness and Endpoint() reporting.
+func newTestClient(t *testing.T, srv *httptest.Server) *SpiderClient {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	creds := base64.StdEncoding.EncodeToString([]byte("default:default"))
+	return &SpiderClient{
+		client:     srv.Client(),
+		host:       u.Hostname(),
+		port:       u.Port(),
+		username:   "default",
+		password:   "default",
+		domain:     srv.URL,
+		authHeader: "Basic " + creds,
+	}
+}
+
+// TestReadyzWithContext_OK verifies cb-spider /readyz happy path.
+func TestReadyzWithContext_OK(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		if r.URL.Path != "/spider/readyz" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"message":"CB-Spider is ready"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.ReadyzWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if !called {
+		t.Fatalf("handler not called")
+	}
+}
+
+// TestAuthCheck_OK verifies the auth-enforced GET /spider/cloudos succeeds
+// with a valid Basic Auth header.
+func TestAuthCheck_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/spider/cloudos" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`["aws","azure","gcp"]`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.AuthCheckWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestAuthCheck_Unauthorized verifies 401 surfaces as ErrUnauthorized so that
+// callers can distinguish authentication failure from other errors and emit a
+// targeted operator message (per STANDARD-READYZ §6.3).
+func TestAuthCheck_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}
+
+// TestAuthCheck_InternalServerError verifies 500 maps to ErrInternalServerError.
+func TestAuthCheck_InternalServerError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrInternalServerError) {
+		t.Fatalf("expected ErrInternalServerError, got %v", err)
+	}
+}
+
+// TestAuthCheck_NetworkFailure verifies a closed server surfaces a non-nil
+// error (Reachable=false case in dependency_check.go).
+func TestAuthCheck_NetworkFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	srv.Close() // close immediately so requests fail
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected non-nil error on closed server")
+	}
+	if errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("network failure should not surface as ErrUnauthorized: %v", err)
+	}
+}

--- a/internal/infra/outbound/tumblebug/tumblebug_client.go
+++ b/internal/infra/outbound/tumblebug/tumblebug_client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -16,7 +17,10 @@ import (
 
 var (
 	ErrBadRequest          = errors.New("bad request")
+	ErrUnauthorized        = errors.New("unauthorized")
 	ErrNotFound            = errors.New("object not found")
+	ErrNotReady            = errors.New("cb-tumblebug not ready")
+	ErrNotInitialized      = errors.New("cb-tumblebug not initialized")
 	ErrInternalServerError = errors.New("tumblebug server has got error")
 )
 
@@ -28,6 +32,16 @@ type TumblebugClient struct {
 	password   string
 	domain     string
 	authHeader string
+}
+
+// readyzResponse mirrors the relevant fields of cb-tumblebug's ReadyzResponse
+// (src/interface/rest/server/common/utility.go RestGetReadyz). cb-tumblebug
+// returns HTTP 200 even when Initialized is false (per STANDARD-READYZ pattern
+// B), so callers must inspect the body to determine actual readiness.
+type readyzResponse struct {
+	Ready       bool   `json:"ready"`
+	Initialized bool   `json:"initialized"`
+	Message     string `json:"message"`
 }
 
 func NewTumblebugClient(client *http.Client) *TumblebugClient {
@@ -47,6 +61,10 @@ func NewTumblebugClient(client *http.Client) *TumblebugClient {
 			),
 		),
 	}
+}
+
+func (t *TumblebugClient) Endpoint() string {
+	return t.domain
 }
 
 func (t *TumblebugClient) withUrl(endpoint string) string {
@@ -80,6 +98,8 @@ func (t *TumblebugClient) requestWithContext(ctx context.Context, method, url st
 
 		if resp.StatusCode == http.StatusNotFound {
 			return nil, ErrNotFound
+		} else if resp.StatusCode == http.StatusUnauthorized {
+			return nil, ErrUnauthorized
 		} else if resp.StatusCode == http.StatusInternalServerError {
 			return nil, ErrInternalServerError
 		} else if resp.StatusCode == http.StatusBadRequest {
@@ -103,15 +123,43 @@ func (t *TumblebugClient) requestWithBaseAuthWithContext(ctx context.Context, me
 	return t.requestWithContext(ctx, method, url, body, map[string]string{"Authorization": t.authHeader})
 }
 
+// ReadyzWithContext calls cb-tumblebug GET /tumblebug/readyz and inspects the
+// response body. Per STANDARD-READYZ §5, cb-tumblebug returns HTTP 200 even
+// when SystemInitialized is false, so a simple status check is insufficient.
+// We require both Ready and Initialized to be true.
 func (t *TumblebugClient) ReadyzWithContext(ctx context.Context) error {
-
 	url := t.withUrl("/readyz")
-	_, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
-
+	body, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
-		log.Error().Msgf("error sending tumblebug readyz request; %v", err)
+		log.Error().Msgf("error sending cb-tumblebug readyz request; %v", err)
 		return err
 	}
 
+	var rz readyzResponse
+	if uerr := json.Unmarshal(body, &rz); uerr != nil {
+		return fmt.Errorf("failed to parse cb-tumblebug readyz response: %w", uerr)
+	}
+
+	if !rz.Ready {
+		return fmt.Errorf("%w: %s", ErrNotReady, rz.Message)
+	}
+	if !rz.Initialized {
+		return fmt.Errorf("%w (Ready=true, Initialized=false): %s", ErrNotInitialized, rz.Message)
+	}
+	return nil
+}
+
+// AuthCheckWithContext calls a lightweight authenticated cb-tumblebug endpoint
+// (GET /tumblebug/cloudInfo) to verify Basic Auth credentials. Per
+// STANDARD-READYZ, /tumblebug/readyz is on the auth-middleware skip list and
+// does not validate credentials. /tumblebug/cloudInfo is enforced and returns
+// a small static cloud metadata payload that is independent of operator data.
+func (t *TumblebugClient) AuthCheckWithContext(ctx context.Context) error {
+	url := t.withUrl("/cloudInfo")
+	_, err := t.requestWithBaseAuthWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		log.Error().Msgf("cb-tumblebug auth check failed (GET /tumblebug/cloudInfo); %v", err)
+		return err
+	}
 	return nil
 }

--- a/internal/infra/outbound/tumblebug/tumblebug_client_test.go
+++ b/internal/infra/outbound/tumblebug/tumblebug_client_test.go
@@ -1,0 +1,135 @@
+package tumblebug
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+)
+
+// newTestClient constructs a TumblebugClient against the given httptest server.
+// withUrl uses only the domain field, so we set domain to the full httptest
+// URL (scheme included). The host/port fields mirror the parsed URL.
+func newTestClient(t *testing.T, srv *httptest.Server) *TumblebugClient {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatalf("parse httptest URL: %v", err)
+	}
+	creds := base64.StdEncoding.EncodeToString([]byte("default:default"))
+	return &TumblebugClient{
+		client:     srv.Client(),
+		host:       u.Hostname(),
+		port:       u.Port(),
+		username:   "default",
+		password:   "default",
+		domain:     srv.URL,
+		authHeader: "Basic " + creds,
+	}
+}
+
+// TestReadyz_FullyReady covers the happy path: HTTP 200 + Ready=true + Initialized=true.
+func TestReadyz_FullyReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tumblebug/readyz") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"initialized":true,"message":"CB-Tumblebug is ready and initialized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.ReadyzWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestReadyz_NotInitialized covers the cb-tumblebug pattern B partial-failure
+// case: HTTP 200 but Initialized=false. Per STANDARD-READYZ §5/§6, this must
+// surface as a distinct error so cm-ant can mark the dependency as not fully
+// healthy even though the HTTP status was 200.
+func TestReadyz_NotInitialized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"ready":true,"initialized":false,"message":"CB-Tumblebug is ready but not initialized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	if !errors.Is(err, ErrNotInitialized) {
+		t.Fatalf("expected ErrNotInitialized, got %v", err)
+	}
+}
+
+// TestReadyz_NotReady covers HTTP 503 + Ready=false.
+func TestReadyz_NotReady(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = w.Write([]byte(`{"ready":false,"initialized":false,"message":"CB-Tumblebug is NOT ready"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	// HTTP 503 maps to a generic unexpected status code error (not 401/404/500
+	// special-cased in requestWithContext). We accept any non-nil error here.
+	if err == nil {
+		t.Fatalf("expected non-nil error for 503")
+	}
+}
+
+// TestReadyz_BadJSON covers malformed body.
+func TestReadyz_BadJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`not-json`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.ReadyzWithContext(context.Background())
+	if err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+// TestAuthCheck_OK verifies the auth-enforced GET /tumblebug/cloudInfo path.
+func TestAuthCheck_OK(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/tumblebug/cloudInfo") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"cspNames":["aws","azure","gcp"]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	if err := c.AuthCheckWithContext(context.Background()); err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+}
+
+// TestAuthCheck_Unauthorized verifies 401 surfaces as ErrUnauthorized.
+func TestAuthCheck_Unauthorized(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Unauthorized"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	err := c.AuthCheckWithContext(context.Background())
+	if !errors.Is(err, ErrUnauthorized) {
+		t.Fatalf("expected ErrUnauthorized, got %v", err)
+	}
+}


### PR DESCRIPTION
## 요약

cm-ant `/ant/readyz`가 cb-spider·cb-tumblebug 의존성에 대해 *인증 헤더가 실제로 통과되는지*를 검증하지 않는 갭을 해소한다.
또한 컨테이너 startup 자체에 *fail-fast 의존성 검증*을 도입해 *healthy인데 기능 불능* 상태 자체를 제거한다.
응답 schema 변경에 맞춰 Swagger spec도 같은 PR에서 재생성·반영했다.

## 배경

이전에는 `/ant/readyz`가 DB ping + cb-spider·cb-tumblebug `/readyz` reachability만 검증했다.
그런데 두 의존성의 `/readyz` endpoint는 *인증 미들웨어 skip 목록*에 있어, cm-ant가 인증 헤더를 빈 값/오타로 보내도 200을 받는다.
그 결과 내부 통합환경 검증 중 cm-ant의 SPIDER 인증 환경변수가 누락된 상태로 컨테이너가 16시간 이상 healthy를 유지하고, cost estimate 호출 시점에야 401이 드러나는 사건이 있었다.

또한 cb-tumblebug `/readyz`는 *Initialized=false 부분 실패 상태에서도 HTTP 200*을 반환하므로, status code만 검증하면 초기화 미완료 상태를 통과시킨다.

## 변경 요지

### 1) outbound client (spider · tumblebug)

- `ErrUnauthorized` sentinel error 추가 + `requestWithContext`에 401 분기
- `AuthCheckWithContext()` 메서드 추가:
  - spider → `GET /spider/cloudos` (인증 강제, 내장 cloud OS 목록 — 운영자 데이터 무관)
  - tumblebug → `GET /tumblebug/cloudInfo` (인증 강제, 작은 cloud 메타)
- tumblebug `ReadyzWithContext`에 body parsing 추가 — `Ready` + `Initialized` 둘 다 true여야 통과 (`ErrNotReady` / `ErrNotInitialized` 분기)
- 외부 endpoint 노출용 `Endpoint()` accessor

위 두 endpoint는 *cm-ant 다른 호출 흐름과 간섭하지 않고*, *민감 정보를 응답에 포함하지 않으며*, *작은 응답 + 운영자 데이터 무관*이라는 기준으로 선정.

### 2) `internal/app/dependency_check.go` (신설)

DB Ping + spider/tumblebug readyz reachability + auth check를 *하나의 함수*에 묶음:

- `checkDependencies(ctx)` → `DepResult{db, spider, tumblebug}` 반환
- `getDependencyStatus(ctx)` → 30초 in-memory 캐시 (mutex + lastCheck), `/ant/readyz` handler가 사용
- `CheckStartupDependencies(ctx)` → 캐시 없이 fresh probe, startup 시 사용.
  성공하면 결과를 캐시에 seed (첫 readyz 호출의 중복 probe 회피)

각 실패 케이스마다 어느 의존성이 어떤 host에서 어떤 환경변수 때문에 실패했는지를 *영문* 메시지로 안내.
예: `cb-spider authentication failed (host=http://cb-spider:1024, HTTP 401). Verify ANT_SPIDER_USERNAME and ANT_SPIDER_PASSWORD env vars (or config Spider.Username/Password) on the cm-ant side`

### 3) `internal/app/server.go`

`AntServer` struct에 spider client·tumblebug client·DB 연결을 직접 보관해 startup hook과 readyz handler가 같은 의존성을 공유.

### 4) `cmd/cm-ant/main.go`

`NewAntServer` 직후 `CheckStartupDependencies(30s timeout)` 호출 → 실패 시 `log.Fatal`로 server 기동 차단.
운영자는 *컨테이너 exited(1) + 명확한 사유 로그*로 즉시 원인을 파악할 수 있다.
Swagger `@version` annotation도 `0.4.0` → `0.6.0`으로 정정.

### 5) `internal/app/common_handler.go`

`/ant/readyz` 응답을 다음 구조로 변경:

```json
{
  "ready": true,
  "initialized": true,
  "message": "CM-Ant is ready",
  "dependencies": {
    "db":        {"reachable": true, "authenticated": true, "lastCheck": "..."},
    "spider":    {"reachable": true, "authenticated": true, "lastCheck": "..."},
    "tumblebug": {"reachable": true, "authenticated": true, "lastCheck": "..."}
  }
}
```

모든 dependency가 reachable + authenticated면 HTTP 200, 그렇지 않으면 HTTP 503.
docker healthcheck가 503을 감지해 컨테이너가 unhealthy로 자동 전이되므로 compose 변경은 불필요.

### 6) Swagger spec 재생성 (`make swag`)

readyz handler 응답 schema가 바뀌었으므로 `make swag`로 `api/docs.go`·`api/swagger.json`·`api/swagger.yaml`을 같은 PR에서 재생성.
새 spec은 `$ref: #/definitions/app.readyzResponse`로 신규 응답 schema를 정확히 반영하고 `@version`은 `0.6.0`이다.

## 호환성 영향

- `/ant/readyz` 응답 body 구조 변경 (`{message}` → `{ready, initialized, message, dependencies}`).
  HTTP 200/503 status로 분기하던 healthcheck는 그대로 호환.
- 컨테이너 startup 정책: 의존성 실패 시 *exited(1)* — `restart: unless-stopped` 정책으로 무한 재시작하면서 매번 명확한 사유 로그 출력.
  *기존*에는 의존성 인증 누락·오타도 healthy로 통과했으므로 이번 변경 후 *그동안 가려져 있던 설정 오류가 즉시 드러난다* — 머지 후 컨테이너가 exited(1)로 보이면 startup log의 영문 메시지에 어떤 환경변수를 확인해야 하는지 적혀 있다.
- Swagger spec(`api/docs.go`·`api/swagger.json`·`api/swagger.yaml`) 동시 갱신 — `@version 0.6.0`.
  cm-mayfly `api.yaml`·cm-butterfly `api.yaml` proxy 같은 downstream consumer는 본 PR 머지 후 *별도 라인업 PR*로 동기화 필요.
- cb-spider · cb-tumblebug 추가 호출 부하: readyz 호출당 GET 2건, 30초 캐싱으로 최대 30초당 2건.

## 테스트

### 단위 (11건 PASS)

- `internal/infra/outbound/spider/spider_client_test.go` 5건 — Readyz OK / AuthCheck OK / 401 → ErrUnauthorized / 500 → ErrInternalServerError / 네트워크 실패
- `internal/infra/outbound/tumblebug/tumblebug_client_test.go` 6건 — Readyz fully-ready / Initialized=false → ErrNotInitialized / 503 / 잘못된 JSON / AuthCheck OK / 401

```
$ go test ./internal/infra/outbound/spider/... ./internal/infra/outbound/tumblebug/... -count=1
ok      github.com/cloud-barista/cm-ant/internal/infra/outbound/spider          0.008s
ok      github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug       0.008s
```

`go build ./...` + `go vet ./...` 본 변경분 경고 없음.

### 통합 e2e (5건 PASS) — C-Mig dev EC2 (t3.xlarge, Ubuntu 24.04)

cm-mayfly v0.5.3 라인업에 본 image (`cm-ant:feat-deps-004` — dev EC2에서 docker build)를 통합해 검증.
라인업 — cb-spider 0.12.32 / cb-tumblebug 0.12.19 / cm-beetle 0.5.3 / cb-mapui 0.12.43 / mc-terrarium 0.1.4 등 22 컨테이너 healthy.

| 시나리오 | 기대 | 결과 |
|---|---|:-:|
| A. 정상 환경 startup | 컨테이너 healthy + readyz 200 + 모든 dependencies `authenticated=true` | ✅ |
| B. cm-ant SPIDER username 빈 값으로 재기동 | 컨테이너 *Restarting (1)* 무한 fail-fast + log에 cb-spider 인증 실패 안내 | ✅ |
| C. cm-ant TUMBLEBUG password 오타로 재기동 | 동일 fail-fast + log에 cb-tumblebug 인증 실패 안내 | ✅ |
| D. cm-ant 정상 startup 후 cb-spider 컨테이너 stop | readyz 503 + `spider.reachable=false` + 진단 메시지 | ✅ |
| E. cb-tumblebug `DELETE /tumblebug/readyz/init` (Initialized=false) | readyz 503 + `tumblebug.authenticated=false` (body parsing 작동) + 복원 후 readyz 200 재확인 | ✅ |

재현 명령은 환경 무관 generic 형태:

```bash
curl -sS http://<cm-ant-host>:8880/ant/readyz | jq
docker ps --format '{{.Names}}\t{{.Status}}' | grep cm-ant
docker logs cm-ant 2>&1 | grep FATAL
```

검증 후 dev `.env`·`docker-compose.override.yaml` 원본 복원 + cm-ant 원본 dev image (`csescsta/cm-ant:bar1320-e2e`, Docker Hub 공개 저장소) 재기동.

1차 e2e 시점의 운영자 메시지는 한국어 prototype이었음. 후속 commit `62a9a16`에서 영문화 — 동작 동일.
Swagger spec 재생성은 후속 commit `3c3f739`에서 처리.

## 푸터

- [BAR-1355](https://mzdevs.atlassian.net/browse/BAR-1355) cm-ant readyz 고도화 — cb-spider·cb-tumblebug 인증 의존성 검증 추가 (0.5.2)
- [BAR-1358](https://mzdevs.atlassian.net/browse/BAR-1358) C-Mig 공통 readyz 표준 신설 (relates — 본 작업이 트리거)
- [BAR-861](https://mzdevs.atlassian.net/browse/BAR-861) cm-ant 연계 시스템 버전 현행화 (parent Epic)
- [BAR-1338](https://mzdevs.atlassian.net/browse/BAR-1338) cm-mayfly v0.5.3 라인업 (발견 작업)