### PR TITLE
fix(load): shorten JMeter connect timeout so unreachable targets fail fast

### DIFF
--- a/internal/core/load/jmx_parser.go
+++ b/internal/core/load/jmx_parser.go
@@ -72,7 +72,7 @@ var jmxHttpSamplerTemplate = map[string]string{
 		<boolProp name="HTTPSampler.use_keepalive">true</boolProp>
 		<boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
 		<stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-		<stringProp name="HTTPSampler.connect_timeout">60000</stringProp>
+		<stringProp name="HTTPSampler.connect_timeout">5000</stringProp>
 		<stringProp name="HTTPSampler.response_timeout">60000</stringProp>
 	</HTTPSamplerProxy>
 	<hashTree/>
@@ -100,7 +100,7 @@ var jmxHttpSamplerTemplate = map[string]string{
 		<boolProp name="HTTPSampler.use_keepalive">true</boolProp>
 		<boolProp name="HTTPSampler.DO_MULTIPART_POST">false</boolProp>
 		<stringProp name="HTTPSampler.embedded_url_re"></stringProp>
-		<stringProp name="HTTPSampler.connect_timeout">60000</stringProp>
+		<stringProp name="HTTPSampler.connect_timeout">5000</stringProp>
 		<stringProp name="HTTPSampler.response_timeout">60000</stringProp>
 	</HTTPSamplerProxy>
 	`,


### PR DESCRIPTION
## 개요

부하 대상이 접근 불가할 때 JMeter 요청이 오래 매달리는 문제를 fast-fail로 개선합니다.

## 배경

e2e 부하테스트 검증 중, 대상이 부하 시작 시점에 접근 불가하면(포트 미개방·웹서버 미기동 등) JMeter 요청이 OS TCP connect 백오프(관측 ~2분/요청)로 매달려, 짧은 지속시간 테스트가 ~10분까지 늘어나고 결과 CSV 생성도 그만큼 지연되는 현상을 실측으로 확인했습니다. 결과 rsync 수집 지연과는 다른 근인으로, JMeter 샘플러의 connect timeout 기본값이 커서 발생합니다.

## 변경

`internal/core/load/jmx_parser.go`의 `HTTPSampler.connect_timeout`을 60000ms → 5000ms로 단축(GET·POST 샘플러 템플릿 양쪽). `response_timeout`(60000ms)은 유지.

## 검증

- `go build ./...` 통과.
- 운영 서버 배포 cm-ant 바이너리에서 `connect_timeout">5000` 반영 확인.
- 접근 불가 대상 부하가 요청당 ~5초 내 실패로 전환되어 총 소요·결과 생성 시간이 크게 단축됨.

---
- [BAR-1395](https://mzdevs.atlassian.net/browse/BAR-1395) 부하테스트 실행 및 결과 구현 (성능검증 API 고도화)
- [BAR-1396](https://mzdevs.atlassian.net/browse/BAR-1396) JMeter 부하 요청 connect timeout 단축 (fast-fail)