### PR TITLE
test(outbound): add httptest unit tests for tumblebug and spider clients

### DIFF
--- a/internal/infra/outbound/spider/price_test.go
+++ b/internal/infra/outbound/spider/price_test.go
@@ -1,0 +1,89 @@
+package spider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetPriceInfo_GET verifies GetPriceInfoWithContext uses the cb-spider
+// v0.12.3 BREAKING contract: GET /spider/priceinfo/vm/{region} with
+// ConnectionName as a query parameter and a Basic Auth header (v0.12.6+ forced
+// auth), replacing the old POST + FilterList body.
+func TestGetPriceInfo_GET(t *testing.T) {
+	const region, conn = "ap-northeast-2", "aws-conn"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET (POST→GET transition), got %s", r.Method)
+		}
+		wantPath := "/spider/priceinfo/vm/" + region
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		if got := r.URL.Query().Get("ConnectionName"); got != conn {
+			t.Errorf("expected ConnectionName query %q, got %q", conn, got)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"meta":{},"cloudPriceList":[{}]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	res, err := c.GetPriceInfoWithContext(context.Background(), "vm", region, PriceInfoReq{ConnectionName: conn})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if len(res.CloudPriceList) != 1 {
+		t.Errorf("expected cloudPriceList parsed, got %+v", res.CloudPriceList)
+	}
+}
+
+// TestGetCostWithResource_AnycallAuthHeader verifies GetCostWithResourceWithContext
+// POSTs to /spider/anycall with the Basic Auth header (cb-spider v0.12.6+ forced
+// auth, BAR-685) and unwraps the anycall OKeyValueList result payload.
+func TestGetCostWithResource_AnycallAuthHeader(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if !strings.HasSuffix(r.URL.Path, "/spider/anycall") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header on anycall")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"FID":"getcostwithresource","IKeyValueList":[{"Key":"in","Value":"x"}],"OKeyValueList":[{"Key":"result","Value":"{}"}]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	res, err := c.GetCostWithResourceWithContext(context.Background(), AnycallReq{ConnectionName: "aws-conn"})
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if res == nil {
+		t.Fatalf("expected non-nil cost result")
+	}
+}
+
+// TestGetCostWithResource_EmptyResult verifies the empty-result sentinel is
+// returned when the anycall response carries no output values.
+func TestGetCostWithResource_EmptyResult(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"FID":"getcostwithresource","IKeyValueList":[],"OKeyValueList":null}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GetCostWithResourceWithContext(context.Background(), AnycallReq{ConnectionName: "aws-conn"})
+	if err == nil {
+		t.Fatalf("expected ErrSpiderCostResultEmpty, got nil")
+	}
+}

--- a/internal/infra/outbound/tumblebug/mci_test.go
+++ b/internal/infra/outbound/tumblebug/mci_test.go
@@ -1,0 +1,95 @@
+package tumblebug
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestGetMci_InfraPath verifies GetMciWithContext targets the cb-tumblebug
+// v0.12.7 BREAKING path (/mci/ → /infra/), sends the Basic Auth header, and
+// parses the renamed "node" response key into the Vm slice.
+func TestGetMci_InfraPath(t *testing.T) {
+	const nsId, mciId = "ant-ns", "ant-mci"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		wantPath := "/tumblebug/ns/" + nsId + "/infra/" + mciId
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ant-mci","name":"ant-mci","status":"Running","node":[{"id":"ant-vm-1"}]}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	res, err := c.GetMciWithContext(context.Background(), nsId, mciId)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if res.Id != "ant-mci" {
+		t.Errorf("unexpected id: got %q", res.Id)
+	}
+	// The response key "node" must populate Vm ([]VmRes json:"node").
+	if len(res.Vm) != 1 || res.Vm[0].Id != "ant-vm-1" {
+		t.Errorf("expected node key parsed into Vm, got %+v", res.Vm)
+	}
+}
+
+// TestGetVm_InfraNodePath verifies GetVmWithContext targets the cb-tumblebug
+// v0.12.7 BREAKING path (/mci/ → /infra/, /vm/ → /node/), sends Basic Auth,
+// and parses the renamed "nodeGroupId" response key into SubGroupId.
+func TestGetVm_InfraNodePath(t *testing.T) {
+	const nsId, mciId, vmId = "ant-ns", "ant-mci", "ant-vm-1"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		wantPath := "/tumblebug/ns/" + nsId + "/infra/" + mciId + "/node/" + vmId
+		if r.URL.Path != wantPath {
+			t.Errorf("unexpected path: got %s, want %s", r.URL.Path, wantPath)
+		}
+		if !strings.HasPrefix(r.Header.Get("Authorization"), "Basic ") {
+			t.Errorf("missing Basic Auth header")
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"id":"ant-vm-1","name":"ant-vm-1","status":"Running","nodeGroupId":"g1"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	res, err := c.GetVmWithContext(context.Background(), nsId, mciId, vmId)
+	if err != nil {
+		t.Fatalf("expected nil, got %v", err)
+	}
+	if res.Id != "ant-vm-1" {
+		t.Errorf("unexpected id: got %q", res.Id)
+	}
+	// The response key "nodeGroupId" must populate SubGroupId.
+	if res.SubGroupId != "g1" {
+		t.Errorf("expected nodeGroupId parsed into SubGroupId, got %q", res.SubGroupId)
+	}
+}
+
+// TestGetMci_NotFound verifies that a cb-tumblebug 500 whose body looks like a
+// missing-resource error is normalized to ErrNotFound.
+func TestGetMci_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`{"message":"does not exist"}`))
+	}))
+	defer srv.Close()
+
+	c := newTestClient(t, srv)
+	_, err := c.GetMciWithContext(context.Background(), "ant-ns", "missing")
+	if err == nil {
+		t.Fatalf("expected error for missing mci")
+	}
+}


### PR DESCRIPTION
## 개요

cm-ant outbound 클라이언트(cb-tumblebug·cb-spider)의 요청 계약을 live 의존 없이 httptest로 검증하는 단위테스트를 추가합니다.

## 변경

- `tumblebug/mci_test.go`: GetMci `/infra/`, GetVm `/infra/{mci}/node/{vm}` 경로 + Basic auth + 응답 키(node·nodeGroupId) 매핑 단언
- `spider/price_test.go`: GetPriceInfo GET `/priceinfo/vm/{region}?ConnectionName=` (POST→GET 전환) + anycall POST Authorization 헤더 송신 단언 + empty-result sentinel

## 검증

`go test ./internal/infra/outbound/tumblebug/... ./internal/infra/outbound/spider/...` → 6 케이스 PASS. 테스트만 추가(런타임 로직 변경 없음).

---
JIRA:
- [BAR-877](https://mzdevs.atlassian.net/browse/BAR-877) [feat][cm-ant] httptest 단위테스트 구현 (URL·Price GET·인증 헤더)

테스트 결과서: cmig-workflow notion cm-ant-ep-테스트자동화/001_동작분석및테스트체계/ST3_단위테스트/TR-MA4-TEST-001-04.md