### PR TITLE
fix(load): record which VM a load test ran on, not just what it was called

### DIFF
--- a/internal/core/load/dtos.go
+++ b/internal/core/load/dtos.go
@@ -8,7 +8,7 @@ import (
 
 // MonitoringAgentInstallationParams represents parameters for installing a monitoring agent.
 type MonitoringAgentInstallationParams struct {
-	NsId  string   `json:"nsId"`
+	NsId    string   `json:"nsId"`
 	InfraId string   `json:"infraId"`
 	NodeIds []string `json:"nodeIds,omitempty"`
 }
@@ -17,8 +17,8 @@ type MonitoringAgentInstallationParams struct {
 type MonitoringAgentInstallationResult struct {
 	ID        uint      `json:"id,omitempty"`
 	NsId      string    `json:"nsId,omitempty"`
-	InfraId     string    `json:"infraId,omitempty"`
-	NodeId      string    `json:"nodeId,omitempty"`
+	InfraId   string    `json:"infraId,omitempty"`
+	NodeId    string    `json:"nodeId,omitempty"`
 	VmCount   int       `json:"vmCount,omitempty"`
 	Status    string    `json:"status,omitempty"`
 	Username  string    `json:"username,omitempty"`
@@ -28,9 +28,9 @@ type MonitoringAgentInstallationResult struct {
 }
 
 type GetAllMonitoringAgentInfosParam struct {
-	Page  int    `json:"page"`
-	Size  int    `json:"size"`
-	NsId  string `json:"nsId,omitempty"`
+	Page    int    `json:"page"`
+	Size    int    `json:"size"`
+	NsId    string `json:"nsId,omitempty"`
 	InfraId string `json:"infraId,omitempty"`
 	NodeId  string `json:"nodeId,omitempty"`
 }
@@ -44,7 +44,7 @@ type InstallLoadGeneratorParam struct {
 	InstallLocation constant.InstallLocation `json:"installLocation,omitempty"`
 	Coordinates     []string                 `json:"coordinate"`
 	// VM 정보 추가 (CSP 매칭용)
-	NsId  string `json:"nsId,omitempty"`
+	NsId    string `json:"nsId,omitempty"`
 	InfraId string `json:"infraId,omitempty"`
 	NodeId  string `json:"nodeId,omitempty"`
 }
@@ -63,7 +63,7 @@ type LoadGeneratorServerResult struct {
 	Lat             string    `json:"lat,omitempty"`
 	Lon             string    `json:"lon,omitempty"`
 	Username        string    `json:"username,omitempty"`
-	NodeId            string    `json:"nodeId,omitempty"`
+	NodeId          string    `json:"nodeId,omitempty"`
 	StartTime       string    `json:"startTime,omitempty"`
 	AdditionalVmKey string    `json:"additionalVmKey,omitempty"`
 	Label           string    `json:"label,omitempty"`
@@ -114,7 +114,7 @@ type RunLoadTestParam struct {
 	RampUpSteps  string `json:"rampUpSteps"`
 
 	// related tumblebug
-	NsId  string `json:"nsId"`
+	NsId    string `json:"nsId"`
 	InfraId string `json:"infraId"`
 	NodeId  string `json:"nodeId"`
 
@@ -146,21 +146,25 @@ type GetAllLoadTestExecutionStateResult struct {
 }
 
 type LoadTestExecutionStateResult struct {
-	ID                          uint                           `json:"id"`
-	LoadGeneratorInstallInfoId  uint                           `json:"loadGeneratorInstallInfoId,omitempty"`
-	LoadGeneratorInstallInfo    LoadGeneratorInstallInfoResult `json:"loadGeneratorInstallInfo,omitempty"`
-	LoadTestKey                 string                         `json:"loadTestKey,omitempty"`
-	ExecutionStatus             constant.ExecutionStatus       `json:"executionStatus,omitempty"`
-	StartAt                     time.Time                      `json:"startAt,omitempty"`
-	FinishAt                    *time.Time                     `json:"finishAt,omitempty"`
-	ExpectedFinishAt            time.Time                      `json:"expectedFinishAt,omitempty"`
-	IconCode                    constant.IconCode              `json:"iconCode"`
-	TotalExpectedExcutionSecond uint64                         `json:"totalExpectedExecutionSecond,omitempty"`
-	FailureMessage              string                         `json:"failureMessage,omitempty"`
-	CompileDuration             string                         `json:"compileDuration,omitempty"`
-	ExecutionDuration           string                         `json:"executionDuration,omitempty"`
-	CreatedAt                   time.Time                      `json:"createdAt,omitempty"`
-	UpdatedAt                   time.Time                      `json:"updatedAt,omitempty"`
+	ID                         uint                           `json:"id"`
+	LoadGeneratorInstallInfoId uint                           `json:"loadGeneratorInstallInfoId,omitempty"`
+	LoadGeneratorInstallInfo   LoadGeneratorInstallInfoResult `json:"loadGeneratorInstallInfo,omitempty"`
+	LoadTestKey                string                         `json:"loadTestKey,omitempty"`
+	// NodeUid identifies which VM this run belongs to. Node ids are names and get reused,
+	// so a caller that keeps showing "the last run for this node" needs the uid to notice
+	// that the answer belongs to a VM that has since been replaced.
+	NodeUid                     string                   `json:"nodeUid,omitempty"`
+	ExecutionStatus             constant.ExecutionStatus `json:"executionStatus,omitempty"`
+	StartAt                     time.Time                `json:"startAt,omitempty"`
+	FinishAt                    *time.Time               `json:"finishAt,omitempty"`
+	ExpectedFinishAt            time.Time                `json:"expectedFinishAt,omitempty"`
+	IconCode                    constant.IconCode        `json:"iconCode"`
+	TotalExpectedExcutionSecond uint64                   `json:"totalExpectedExecutionSecond,omitempty"`
+	FailureMessage              string                   `json:"failureMessage,omitempty"`
+	CompileDuration             string                   `json:"compileDuration,omitempty"`
+	ExecutionDuration           string                   `json:"executionDuration,omitempty"`
+	CreatedAt                   time.Time                `json:"createdAt,omitempty"`
+	UpdatedAt                   time.Time                `json:"updatedAt,omitempty"`
 	// Steps is the per-stage progress of the run (FR-MA2-PERF-007-08), ordered by seq.
 	Steps []LoadTestExecutionStepResult `json:"steps,omitempty"`
 }
@@ -182,8 +186,8 @@ type LoadTestExecutionStepResult struct {
 type GetLoadTestExecutionStateParam struct {
 	LoadTestKey string `json:"loadTestKey"`
 	NsId        string `json:"nsId"`
-	InfraId       string `json:"infraId"`
-	NodeId        string `json:"nodeId"`
+	InfraId     string `json:"infraId"`
+	NodeId      string `json:"nodeId"`
 }
 
 type GetAllLoadTestExecutionInfosParam struct {
@@ -230,8 +234,8 @@ type GetLoadTestExecutionInfoParam struct {
 type StopLoadTestParam struct {
 	LoadTestKey string `json:"loadTestKey"`
 	NsId        string `json:"nsId"`
-	InfraId       string `json:"infraId"`
-	NodeId        string `json:"nodeId"`
+	InfraId     string `json:"infraId"`
+	NodeId      string `json:"nodeId"`
 }
 
 type ResultSummary struct {
@@ -286,10 +290,10 @@ type GetLoadTestResultParam struct {
 }
 
 type GetLastLoadTestResultParam struct {
-	NsId   string
-	InfraId  string
-	NodeId   string
-	Format constant.ResultFormat
+	NsId    string
+	InfraId string
+	NodeId  string
+	Format  constant.ResultFormat
 }
 
 // LoadTestScenarioCatalog DTOs

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -102,6 +102,24 @@ var generatorRunMu sync.Mutex
 // RunLoadTest initiates the load test and performs necessary initializations.
 // Generates a load test key, installs the load generator or retrieves existing installation information,
 // saves the load test execution state, and then asynchronously runs the load test.
+// resolveNodeUid asks cb-tumblebug which VM the given node name currently refers to.
+//
+// Returns "" when the lookup fails. A load test is worth running even if we cannot label it,
+// and an empty uid is understood downstream as "unknown" rather than as a mismatch - the
+// same treatment rows written before this column existed get.
+func (l *LoadService) resolveNodeUid(ctx context.Context, nsId, infraId, nodeId string) string {
+	if nsId == "" || infraId == "" || nodeId == "" {
+		return ""
+	}
+
+	vm, err := l.tumblebugClient.GetVmWithContext(ctx, nsId, infraId, nodeId)
+	if err != nil {
+		log.Warn().Msgf("could not resolve node uid for %s/%s/%s: %v", nsId, infraId, nodeId, err)
+		return ""
+	}
+	return vm.Uid
+}
+
 func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 	timeout, err := time.ParseDuration(config.AppConfig.Load.Timeout.CommandExecution)
 	if err != nil {
@@ -142,6 +160,17 @@ func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 	startAt := time.Now()
 	e := startAt.Add(time.Duration(totalExecutionSecond) * time.Second)
 
+	// Record which VM this run belongs to, not just what it was called.
+	//
+	// Node ids are names that get reused: cb-tumblebug builds them as "{group}-{index}", so
+	// deleting a VM and recreating it under the same name gives an identical
+	// ns/infra/node triple. Without the uid a later lookup cannot tell whether the run it
+	// found belongs to the VM in front of the user or to its predecessor.
+	//
+	// Resolved here rather than taken from the request: the client would have to send it
+	// correctly for the guarantee to hold, and cb-tumblebug already answers the question.
+	nodeUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
+
 	stateArg := LoadTestExecutionState{
 		LoadTestKey:                 loadTestKey,
 		ExecutionStatus:             constant.OnProcessing,
@@ -151,6 +180,7 @@ func (l *LoadService) RunLoadTest(param RunLoadTestParam) (string, error) {
 		NsId:                        param.NsId,
 		InfraId:                     param.InfraId,
 		NodeId:                      param.NodeId,
+		NodeUid:                     nodeUid,
 		WithMetrics:                 param.CollectAdditionalSystemMetrics,
 	}
 
@@ -657,6 +687,20 @@ func generateJmeterExecutionCmd(loadGeneratorInstallPath, loadGeneratorInstallVe
 	return builder.String()
 }
 
+// belongsToDifferentNode reports whether a recorded run demonstrably belongs to a VM other
+// than the one being asked about.
+//
+// Only a disagreement between two known uids counts. An unknown uid on either side - a run
+// recorded before the column existed, or cb-tumblebug being unreachable - is not evidence of
+// anything, and treating it as a mismatch would block stopping runs that are perfectly
+// legitimate.
+func belongsToDifferentNode(recordedUid, currentUid string) bool {
+	if recordedUid == "" || currentUid == "" {
+		return false
+	}
+	return recordedUid != currentUid
+}
+
 func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -680,6 +724,26 @@ func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 
 	if err != nil {
 		return fmt.Errorf("error occurred while retrieve load test execution state: %w", err)
+	}
+
+	// Stopping by name alone can hit the wrong run.
+	//
+	// Without a load test key the lookup above is "the most recent run for this ns/infra/node",
+	// and those are names that get reused - a VM recreated under the old name inherits them.
+	// The run that comes back may therefore belong to the previous VM, and stopping it would
+	// kill a test nobody asked to stop. Reading is merely misleading; this is destructive.
+	//
+	// A stored uid that disagrees with the live one means exactly that case. An empty uid on
+	// either side means "unknown" (rows predating the column, or cb-tumblebug unreachable) and
+	// is left alone rather than guessed at.
+	if param.LoadTestKey == "" {
+		currentUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
+		if belongsToDifferentNode(state.NodeUid, currentUid) {
+			return fmt.Errorf(
+				"the most recent load test on %s/%s/%s belongs to a different VM (recorded uid %s, current uid %s); pass its load test key to stop it",
+				param.NsId, param.InfraId, param.NodeId, state.NodeUid, currentUid,
+			)
+		}
 	}
 
 	if state.ExecutionStatus == constant.Successed {

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -726,16 +726,18 @@ func (l *LoadService) StopLoadTest(param StopLoadTestParam) error {
 		return fmt.Errorf("error occurred while retrieve load test execution state: %w", err)
 	}
 
-	// Stopping by name alone can hit the wrong run.
+	// Guard the key-less lookup, which resolves to "the most recent run for this
+	// ns/infra/node" - names that get reused, so the run may belong to a VM that has since
+	// been replaced. Stopping that one would kill a test nobody asked about.
 	//
-	// Without a load test key the lookup above is "the most recent run for this ns/infra/node",
-	// and those are names that get reused - a VM recreated under the old name inherits them.
-	// The run that comes back may therefore belong to the previous VM, and stopping it would
-	// kill a test nobody asked to stop. Reading is merely misleading; this is destructive.
+	// Not reachable over HTTP today: the handler rejects a stop request that omits the load
+	// test key, so callers always arrive with one and take the branch above. The guard is
+	// here because the service accepts the key-less shape and nothing but this handler check
+	// stands between it and the wrong test.
 	//
-	// A stored uid that disagrees with the live one means exactly that case. An empty uid on
-	// either side means "unknown" (rows predating the column, or cb-tumblebug unreachable) and
-	// is left alone rather than guessed at.
+	// A stored uid that disagrees with the live one is that case. An empty uid on either side
+	// means "unknown" (rows predating the column, or cb-tumblebug unreachable) and is left
+	// alone rather than guessed at.
 	if param.LoadTestKey == "" {
 		currentUid := l.resolveNodeUid(ctx, param.NsId, param.InfraId, param.NodeId)
 		if belongsToDifferentNode(state.NodeUid, currentUid) {

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -15,8 +15,8 @@ type MonitoringAgentInfo struct {
 	AgentType string
 
 	NsId    string
-	InfraId   string
-	NodeId    string
+	InfraId string
+	NodeId  string
 	VmCount int
 }
 
@@ -37,7 +37,7 @@ type LoadGeneratorServer struct {
 	Lat             string
 	Lon             string
 	Username        string
-	NodeId            string
+	NodeId          string
 	StartTime       string
 	AdditionalVmKey string
 	Label           string
@@ -77,9 +77,22 @@ type LoadTestExecutionState struct {
 	gorm.Model
 	LoadTestKey string `gorm:"index:idx_state_load_test_key,unique"`
 
-	NsId  string
+	NsId    string
 	InfraId string
 	NodeId  string
+
+	// NodeUid is cb-tumblebug's generated identifier for the node under test.
+	//
+	// NsId/InfraId/NodeId are *names*: cb-tumblebug builds a node id as "{group name}-{index
+	// within the group}" and reuses it when the same names are used again. Deleting a VM and
+	// recreating it with the same name therefore produces an identical NsId/InfraId/NodeId,
+	// and a lookup by those alone returns the previous VM's run - a result belonging to a
+	// machine that no longer exists. Only the uid is regenerated per VM, so it is what tells
+	// two generations apart.
+	//
+	// Empty for runs recorded before this column existed; callers must treat "" as unknown
+	// rather than as a mismatch.
+	NodeUid string
 
 	ExecutionStatus             constant.ExecutionStatus
 	StartAt                     time.Time
@@ -124,7 +137,7 @@ type LoadTestExecutionInfo struct {
 	RampUpTime   string
 	RampUpSteps  string
 
-	NsId  string
+	NsId    string
 	InfraId string
 	NodeId  string
 

--- a/internal/core/load/node_uid_test.go
+++ b/internal/core/load/node_uid_test.go
@@ -1,0 +1,82 @@
+package load
+
+import "testing"
+
+// These tests exist because cb-tumblebug node ids are names, not identities. A node id is
+// built as "{group name}-{index within the group}", so deleting a VM and recreating it under
+// the same name yields an identical ns/infra/node triple. Runs recorded against that triple
+// alone cannot be attributed to a particular VM; only the uid, regenerated per VM, can.
+
+// TestBelongsToDifferentNode covers the decision that guards stopping a load test.
+//
+// Getting this wrong is destructive in one direction and obstructive in the other: too
+// lenient and a stop request kills a run belonging to the VM's predecessor, too strict and
+// legitimate stops start failing for runs recorded before the uid existed.
+func TestBelongsToDifferentNode(t *testing.T) {
+	cases := []struct {
+		name        string
+		recordedUid string
+		currentUid  string
+		want        bool
+		why         string
+	}{
+		{
+			name:        "same vm",
+			recordedUid: "tbaaa111",
+			currentUid:  "tbaaa111",
+			want:        false,
+			why:         "the run belongs to the VM being asked about",
+		},
+		{
+			name:        "recreated under the same name",
+			recordedUid: "tbaaa111",
+			currentUid:  "tbbbb222",
+			want:        true,
+			why:         "same names, different VM - this is the case worth refusing",
+		},
+		{
+			name:        "run predates the uid column",
+			recordedUid: "",
+			currentUid:  "tbbbb222",
+			want:        false,
+			why:         "unknown is not a mismatch; refusing would block old but valid runs",
+		},
+		{
+			name:        "cb-tumblebug could not be reached",
+			recordedUid: "tbaaa111",
+			currentUid:  "",
+			want:        false,
+			why:         "a failed lookup says nothing about which VM this is",
+		},
+		{
+			name:        "neither side known",
+			recordedUid: "",
+			currentUid:  "",
+			want:        false,
+			why:         "no evidence either way",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := belongsToDifferentNode(c.recordedUid, c.currentUid); got != c.want {
+				t.Errorf("belongsToDifferentNode(%q, %q) = %v, want %v — %s",
+					c.recordedUid, c.currentUid, got, c.want, c.why)
+			}
+		})
+	}
+}
+
+// TestMapLoadTestExecutionStateResult_ExposesNodeUid makes sure callers can tell which VM a
+// run belongs to. Without the uid in the response the console cannot notice that "the last
+// run for this node" describes a VM that has since been replaced.
+func TestMapLoadTestExecutionStateResult_ExposesNodeUid(t *testing.T) {
+	got := mapLoadTestExecutionStateResult(LoadTestExecutionState{
+		LoadTestKey: "key-1",
+		NodeUid:     "tbabc123def456ghi789",
+	})
+
+	if got.NodeUid != "tbabc123def456ghi789" {
+		t.Errorf("expected the node uid to reach the response, got %q", got.NodeUid)
+	}
+}

--- a/internal/core/load/performace_evaluation_service.go
+++ b/internal/core/load/performace_evaluation_service.go
@@ -152,6 +152,7 @@ func mapLoadTestExecutionStateResult(state LoadTestExecutionState) LoadTestExecu
 	stateResult := &LoadTestExecutionStateResult{
 		ID:                          state.ID,
 		LoadTestKey:                 state.LoadTestKey,
+		NodeUid:                     state.NodeUid,
 		ExecutionStatus:             state.ExecutionStatus,
 		StartAt:                     state.StartAt,
 		FinishAt:                    state.FinishAt,
@@ -205,7 +206,7 @@ func mapLoadGeneratorServerResult(s LoadGeneratorServer) LoadGeneratorServerResu
 		Lat:             s.Lat,
 		Lon:             s.Lon,
 		Username:        s.Username,
-		NodeId:            s.NodeId,
+		NodeId:          s.NodeId,
 		StartTime:       s.StartTime,
 		AdditionalVmKey: s.AdditionalVmKey,
 		Label:           s.Label,


### PR DESCRIPTION
## 배경

부하 테스트 실행 기록을 **이름으로만 조회**한다. cb-tumblebug 의 node id 는 `{그룹 이름}-{그룹 내 순번}` 이고 ns·infra 도 이름이라, **VM 을 지우고 같은 이름으로 다시 만들면 이전 VM 의 결과가 반환된다.**

```go
// internal/core/load/repository.go:401-419
q.Where("...ns_id = ?", param.NsId)
q.Where("...infra_id = ?", param.InfraId)
q.Where("...node_id = ?", param.NodeId)
q.Order("start_at desc").Limit(1)
```

상태·이력 테이블 어디에도 uid 컬럼이 없어 **두 세대를 구분할 정보 자체가 없었다.**

## 개발 서버 실측 (실제 AWS VM)

VM 을 만들어 부하 테스트를 돌리고, 그 VM 을 지운 뒤 같은 이름으로 다시 만들어 조회했다.

```
node id  : ant1546b-1              ← 재생성 후에도 동일
이전 VM uid : tbrpboek68u32f3s9l1j
현재 VM uid : tblf70ek0dtjuvhf35si

state/last → 이전 VM 의 실행이 반환됨
```

## 변경

| 계층 | 내용 |
|---|---|
| 모델 | `LoadTestExecutionState.NodeUid` 추가 (AutoMigrate, 기존 행은 빈 값) |
| 실행 | 시작 시 cb-tumblebug 에서 uid 를 조회해 저장 |
| 응답 | `nodeUid` 노출 (매핑 한 곳 수정으로 관련 경로 모두 반영) |
| 중단 | 키 없는 경로에서 uid 대조 (도달하지 않는 경로에 대한 방어 — 아래) |

**uid 는 서버가 직접 얻는다.** 요청 필드로 받지 않는 이유는 단순하다 — 모든 클라이언트가 올바로 보내야만 성립하는 보장은 보장이 아니다. cm-ant 는 이미 cb-tumblebug 클라이언트로 VM 을 조회하고 `uid` 를 파싱하고 있어 새로 만들 것도 없다.

## "모른다" 를 "다르다" 로 취급하지 않는다

| 기록된 uid | 현재 uid | 판정 |
|---|---|---|
| 있음 · 다름 | 있음 | 다른 VM |
| 없음(옛 기록) | 있음 | 판단 보류 |
| 있음 | 없음(조회 실패) | 판단 보류 |

컬럼이 생기기 전 기록과 cb-tumblebug 일시 장애가 정상 동작을 막으면 안 된다. 이 판단만 순수 함수로 떼어 **5가지 경우를 테스트로 고정**했다 — 느슨하면 남의 실행을 중단하고, 엄격하면 정상 중단을 막는 유일한 지점이라서다.

## 조회 동작 자체는 바꾸지 않았다

`state/last` 가 "그 이름의 마지막 실행" 을 돌려주는 것은 그 질문에 대한 맞는 답이고, *지금 보고 있는 VM 것인지* 는 호출자가 판단할 문제다. 서버가 임의로 숨기면 이력 조회 같은 다른 쓰임을 막는다. 그래서 **판단 재료(uid)만 추가**했다.

## 착수 시 판단을 하나 정정했다

`stop` 이 이름으로 최신 실행을 찾아 엉뚱한 실행을 죽일 수 있다고 봤으나 **REST 로는 도달하지 않는다.** 핸들러가 `loadTestKey` 를 항상 요구한다(`evaluate_performance_handler.go:315-317`). 이름만 넣어 호출해 400 을 확인했다.

방어는 남긴다 — 서비스가 키 없는 형태를 받아들이고 그 사이에 있는 것은 핸들러 검사 하나뿐이다. 다만 긴급도는 조회 경로에 있다.

## 검증

- `go build` · `go vet` · `go test ./...` 통과
- 원격 개발 서버에 CI 이미지로 기동 — 컬럼 자동 생성, 실행 시 uid 저장(tumblebug 값과 일치), 응답 노출 확인
- 결함 재현 후 uid 로 구분 가능함을 확인
- 검증에 쓴 VM 은 terminate, 검증용 DB 행·컨테이너 제거

> `models.go` 의 다른 구조체 정렬이 함께 바뀐 것은 gofmt 가 파일 전체에 적용되기 때문이다.