### PR TITLE
Report load test progress as phases with timings, and check the environment first

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ This feature provides:
 
 These functionalities are integrated with other subsystems, namely `CB-Tumblebug` and `CB-Spider`, to function properly. Therefore, for CM-ANT to operate correctly, the related subsystems must be running on the same environment.
 
+A load test also needs the target itself to be reachable — the port under test and, when
+system metrics are collected, port `5555`. See
+[Load test — prerequisites and what the messages mean](docs/load-test-troubleshooting.md) for
+what has to be open before a run and what each step message means when something is not.
+
 ### OS Image Search Configuration
 CM-ANT uses CB-Tumblebug's smart image search API to dynamically find appropriate OS images for load testing VM instances. The system supports two modes for image selection:
 

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -1,0 +1,72 @@
+# Load test — prerequisites and what the messages mean
+
+A load test reaches across three machines: cm-ant orchestrates, a generator VM produces the
+load, and the target VM receives it while reporting its own cpu and memory. Most failures are
+about one of them not being reachable from another, so this page lists what has to be open
+before a run, and what each message means when something is not.
+
+## Before running
+
+### Ports on the target
+
+| Port | Needed for | If closed |
+|---|---|---|
+| The port under test (e.g. 80) | The load itself | The run stops during the precheck |
+| **5555** | System metrics — cpu, memory, disk, network | The run stops during the precheck |
+| 22 | Installing and starting the metric agent | The run stops during the precheck |
+
+Both the load port and 5555 must allow inbound traffic in the target's security group.
+
+**5555 is not optional when metrics are requested.** Every chart on the results screen other
+than response time is drawn from what comes through it, so a run that cannot reach it stops
+rather than spending several minutes to arrive at response times alone.
+
+If system performance figures are not needed, clear **Collect Additional System Metrics** in
+the load configuration. The run then skips the metric agent entirely and 5555 is not required.
+
+### The target itself
+
+- The node exists and is `Running`
+- The service under test answers on the configured path — the precheck sends the same request
+  the load will send, so a path that returns 404 is reported before the run starts
+- Remote commands work, since everything cm-ant does to the target and the generator goes
+  through cb-tumblebug's remote command
+
+## The precheck
+
+A run begins by checking the above. These answers arrive in seconds, so a wrong environment is
+reported immediately instead of surfacing minutes into a run that was never going to work.
+
+Each check is retried up to three times before it is called a failure. A healthy target answers
+on the first attempt, so the retries cost nothing when things are fine, and a lost packet does
+not get reported as a firewall problem. When a check needs more than one attempt the step says
+so — `(attempt 2 of 3)` is worth noticing even when the check eventually passes.
+
+## Messages
+
+Each step shows a short line, with the explanation behind it on hover.
+
+| Message | What happened | What to do |
+|---|---|---|
+| `Target node not found` | cb-tumblebug has no such node | Check the namespace, infra and node ids |
+| `Target node is Suspended, not running` | The node exists but is not running | Start the node |
+| `Target port 80 unreachable` | Nothing answered the configured request | Check, in order: the service is listening on the target, the security group allows inbound on that port, the node has a reachable address |
+| `Target answered with status 404` | The target is alive but that path is not serving | Check the request path. The run continues — an endpoint that returns an error may be what you meant to test |
+| `Metric port 5555 closed` | The metric agent port is not reachable | Add 5555 inbound to the security group and run again, or clear **Collect Additional System Metrics** to run without them |
+| `Remote command failed on the target` | cb-tumblebug could not run a command on the node | Check SSH access and the node agent. Nothing else can proceed without this |
+| `Metric agent not running` | The agent was installed but no process is up | Check java on the target and `/opt/perfmon-agent`. The install script starts the agent with nohup and reports success either way, so this means it did not stay up |
+| `Metric agent silent on port 5555` | The process is up but nothing answers | The process being up rules out a failed start, so this is almost always the security group |
+| `Results collected, without network metrics` | The load figures are in; one metric file never arrived | The charts for that metric will be empty. The run is otherwise complete |
+
+## While a run is going
+
+Steps are grouped by phase, and every step carries how long it has taken — the whole span once
+finished, the time so far while running. A step that normally takes a second and now reads
+`45s` is the one to look at.
+
+Metric files are written during the run and routinely arrive after the main result, so
+collection keeps going while files are still arriving and stops once a round brings nothing
+new. Files that never came are named rather than silently missing.
+
+A missing metric file does not fail the run. Only the main result does — the load figures are
+what the run is for.

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -75,9 +75,11 @@ The install script records what it is doing as it goes, so the step message name
 rather than just counting seconds — `Installing the agent - downloading the agent (45s)`. That
 is the difference between a slow mirror and a stuck install, and it is also how a *failed*
 install becomes visible: a dead install leaves no process behind, which from outside looks
-exactly like one that never started. The script writes its phase to
-`/var/tmp/cm-ant-agent-install.state` and the full sequence to
-`/var/tmp/cm-ant-agent-install.log`; both are worth reading when a target keeps failing.
+exactly like one that never started.
+
+The script writes its current phase to `/var/tmp/cm-ant-agent-install.state` and the whole
+sequence, across reinstalls, to `/var/tmp/cm-ant-agent-install.log`. Both are worth reading
+when a target keeps failing — the log shows how far each round got before it stopped.
 
 The step does not simply wait out a fixed time. While no agent process is there, it asks the
 target what the install is doing, and:

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -69,8 +69,18 @@ Each step shows a short line, with the explanation behind it on hover.
 
 The agent install fetches a JRE through apt and then unpacks the agent release, so on a target
 that has never run a load test it takes a while — usually well under a minute, longer on a
-small instance or a slow mirror. The step does not simply wait out a fixed time. While no agent
-process is there, it asks the target whether an install is still running, and:
+small instance or a slow mirror.
+
+The install script records what it is doing as it goes, so the step message names the phase
+rather than just counting seconds — `Installing the agent - downloading the agent (45s)`. That
+is the difference between a slow mirror and a stuck install, and it is also how a *failed*
+install becomes visible: a dead install leaves no process behind, which from outside looks
+exactly like one that never started. The script writes its phase to
+`/var/tmp/cm-ant-agent-install.state` and the full sequence to
+`/var/tmp/cm-ant-agent-install.log`; both are worth reading when a target keeps failing.
+
+The step does not simply wait out a fixed time. While no agent process is there, it asks the
+target what the install is doing, and:
 
 - **an install is running** — it keeps waiting, up to two minutes, reporting the elapsed time
 - **nothing is running** — there is nothing to wait for, so it reinstalls immediately rather

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -12,7 +12,7 @@ before a run, and what each message means when something is not.
 | Port | Needed for | If closed |
 |---|---|---|
 | The port under test (e.g. 80) | The load itself | The run stops during the precheck |
-| **5555** | System metrics — cpu, memory, disk, network | The run stops during the precheck |
+| **5555** | System metrics — cpu, memory, disk, network | The run stops during the precheck. The agent only needs the port open; the run installs it |
 | 22 | Installing and starting the metric agent | The run stops during the precheck |
 
 Both the load port and 5555 must allow inbound traffic in the target's security group.
@@ -20,6 +20,12 @@ Both the load port and 5555 must allow inbound traffic in the target's security 
 **5555 is not optional when metrics are requested.** Every chart on the results screen other
 than response time is drawn from what comes through it, so a run that cannot reach it stops
 rather than spending several minutes to arrive at response times alone.
+
+What the precheck settles about 5555 is whether the port is *open*, not whether the agent is
+already running on it. The agent is installed by the run itself, so a port that answers with a
+refusal — open, nothing listening yet — is the normal state of a target that has not been used
+for a load test before, and the run carries on to install. A port that answers nothing at all
+is the security group, and no later step can undo that, so the run stops there.
 
 If system performance figures are not needed, clear **Collect Additional System Metrics** in
 the load configuration. The run then skips the metric agent entirely and 5555 is not required.
@@ -52,11 +58,28 @@ Each step shows a short line, with the explanation behind it on hover.
 | `Target node is Suspended, not running` | The node exists but is not running | Start the node |
 | `Target port 80 unreachable` | Nothing answered the configured request | Check, in order: the service is listening on the target, the security group allows inbound on that port, the node has a reachable address |
 | `Target answered with status 404` | The target is alive but that path is not serving | Check the request path. The run continues — an endpoint that returns an error may be what you meant to test |
-| `Metric port 5555 closed` | The metric agent port is not reachable | Add 5555 inbound to the security group and run again, or clear **Collect Additional System Metrics** to run without them |
+| `Metric port 5555 unreachable` | Nothing answered on 5555 at all — the traffic is being dropped | Add 5555 inbound to the security group and run again, or clear **Collect Additional System Metrics** to run without them. Installing the agent cannot help while the port is closed |
+| `Metric agent could not be started` | Two install rounds ended without an agent process | The detail lists what each round saw. Check java on the target, that `/opt/perfmon-agent` holds the unpacked agent, and that nothing else is bound to 5555 |
 | `Remote command failed on the target` | cb-tumblebug could not run a command on the node | If the node started recently, wait a few minutes and try again (see below). Otherwise check port 22 and the address cb-tumblebug holds for the node |
 | `Metric agent not running` | The agent was installed but no process is up | Check java on the target and `/opt/perfmon-agent`. The install script starts the agent with nohup and reports success either way, so this means it did not stay up |
 | `Metric agent silent on port 5555` | The process is up but nothing answers | The process being up rules out a failed start, so this is almost always the security group |
 | `Results collected, without network metrics` | The load figures are in; one metric file never arrived | The charts for that metric will be empty. The run is otherwise complete |
+
+## Installing the metric agent
+
+The agent install fetches a JRE through apt and then unpacks the agent release, so on a target
+that has never run a load test it takes a while — usually well under a minute, longer on a
+small instance or a slow mirror. The step does not simply wait out a fixed time. While no agent
+process is there, it asks the target whether an install is still running, and:
+
+- **an install is running** — it keeps waiting, up to two minutes, reporting the elapsed time
+- **nothing is running** — there is nothing to wait for, so it reinstalls immediately rather
+  than spending the ceiling on a wait that was never going to end
+
+An install that reaches the ceiling, or ends without leaving an agent behind, gets one more
+round. Two rounds that both end without an agent are reported as `Metric agent could not be
+started`, and the detail says what each round saw — an install still running after two minutes
+is a different problem from an install that finished and left nothing.
 
 ## When a node has just started
 

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -81,17 +81,24 @@ The script writes its current phase to `/var/tmp/cm-ant-agent-install.state` and
 sequence, across reinstalls, to `/var/tmp/cm-ant-agent-install.log`. Both are worth reading
 when a target keeps failing — the log shows how far each round got before it stopped.
 
-The step does not simply wait out a fixed time. While no agent process is there, it asks the
-target what the install is doing, and:
+The long stages report a figure that advances with the work — apt's current line, the bytes
+downloaded so far — and that is what makes a slow install distinguishable from a dead one.
+Waiting is decided on movement, not on elapsed time:
 
-- **an install is running** — it keeps waiting, up to two minutes, reporting the elapsed time
-- **nothing is running** — there is nothing to wait for, so it reinstalls immediately rather
-  than spending the ceiling on a wait that was never going to end
+- **the report keeps changing** — work is happening, so it keeps waiting, up to five minutes
+- **the report has not changed in 90 seconds** — the install has stopped where it stands, and
+  more time will not help
+- **the script recorded a failure, or nothing is running** — there is nothing to wait for, so
+  it reinstalls at once rather than spending the ceiling on a wait that was never going to end
 
-An install that reaches the ceiling, or ends without leaving an agent behind, gets one more
-round. Two rounds that both end without an agent are reported as `Metric agent could not be
-started`, and the detail says what each round saw — an install still running after two minutes
-is a different problem from an install that finished and left nothing.
+The ceiling is deliberately generous, because a download over a bad link can honestly take
+minutes and cutting it off would only start the same slow download again. The stall window is
+what catches an install that has died, whatever is left of the ceiling.
+
+A round that ends any of those ways gets one more. Two rounds that both end without an agent
+are reported as `Metric agent could not be started`, and the detail says what each round saw —
+`stuck at 'downloading the agent' - no progress for 1m35s` and `the install stopped at 'install
+failed: exit 100 at line 88' and left no agent process` point at quite different problems.
 
 ## When a node has just started
 

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -66,6 +66,11 @@ small instance types take longer. The check waits ten seconds per attempt rather
 through it, so the answer comes back quickly and the run can be retried once the node has
 settled.
 
+Before running again, confirm you can reach port 22 yourself. A plain `ssh` from outside the
+platform settles in one step what the message can only guess at — whether the security group
+allows it, whether anything else in front of the node is filtering, and whether the ssh service
+is up at all. A run started while that is still failing will fail the same way.
+
 A stop and start also gives the node a new public address. cb-tumblebug picks the new one up
 when the node is stopped and started through it, but the two can drift apart — if a run fails
 to reach a node that looks healthy in the provider console, compare the address cb-tumblebug

--- a/docs/load-test-troubleshooting.md
+++ b/docs/load-test-troubleshooting.md
@@ -53,10 +53,23 @@ Each step shows a short line, with the explanation behind it on hover.
 | `Target port 80 unreachable` | Nothing answered the configured request | Check, in order: the service is listening on the target, the security group allows inbound on that port, the node has a reachable address |
 | `Target answered with status 404` | The target is alive but that path is not serving | Check the request path. The run continues — an endpoint that returns an error may be what you meant to test |
 | `Metric port 5555 closed` | The metric agent port is not reachable | Add 5555 inbound to the security group and run again, or clear **Collect Additional System Metrics** to run without them |
-| `Remote command failed on the target` | cb-tumblebug could not run a command on the node | Check SSH access and the node agent. Nothing else can proceed without this |
+| `Remote command failed on the target` | cb-tumblebug could not run a command on the node | If the node started recently, wait a few minutes and try again (see below). Otherwise check port 22 and the address cb-tumblebug holds for the node |
 | `Metric agent not running` | The agent was installed but no process is up | Check java on the target and `/opt/perfmon-agent`. The install script starts the agent with nohup and reports success either way, so this means it did not stay up |
 | `Metric agent silent on port 5555` | The process is up but nothing answers | The process being up rules out a failed start, so this is almost always the security group |
 | `Results collected, without network metrics` | The load figures are in; one metric file never arrived | The charts for that metric will be empty. The run is otherwise complete |
+
+## When a node has just started
+
+Remote command failures right after a node starts are usually a matter of timing rather than
+configuration. On AWS, ssh can take several minutes to accept connections after a boot, and
+small instance types take longer. The check waits ten seconds per attempt rather than sitting
+through it, so the answer comes back quickly and the run can be retried once the node has
+settled.
+
+A stop and start also gives the node a new public address. cb-tumblebug picks the new one up
+when the node is stopped and started through it, but the two can drift apart — if a run fails
+to reach a node that looks healthy in the provider console, compare the address cb-tumblebug
+holds against the one the provider shows.
 
 ## While a run is going
 

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -100,6 +100,12 @@ const (
 	StepSkipped StepStatus = "skipped"
 )
 
+// Terminal reports whether a step has stopped for good. Anything after a terminal step that is
+// still pending was never reached, so timings must not keep running against it.
+func (s StepStatus) Terminal() bool {
+	return s == StepOk || s == StepFailed || s == StepSkipped
+}
+
 type ResultFormat string
 
 const (

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -1,5 +1,7 @@
 package constant
 
+import "strings"
+
 type InstallLocation string
 
 const (
@@ -25,13 +27,67 @@ const (
 // ExecutionStep identifies a stage of a load test run (FR-MA2-PERF-007-08).
 type ExecutionStep string
 
+// The phases a run goes through. These are what the console shows as the top row.
 const (
+	StepPrecheck         ExecutionStep = "precheck"
 	StepGeneratorInstall ExecutionStep = "generator_install"
 	StepAgentInstall     ExecutionStep = "agent_install"
 	StepJmxPrepare       ExecutionStep = "jmx_prepare"
 	StepJmeterRun        ExecutionStep = "jmeter_run"
 	StepResultFetch      ExecutionStep = "result_fetch"
 )
+
+// Sub-steps. A phase on its own cannot say where the time went: a run that spent 27 minutes
+// unable to reach the metric agent looked exactly like one that was busy generating load,
+// because both are "jmeter_run". Each sub-step below is something that can be waited on, so
+// it carries its own start and finish time (BAR-1553).
+const (
+	// precheck — answered in seconds, before anything is provisioned
+	SubTargetExists     ExecutionStep = "precheck.target_exists"
+	SubTargetRunning    ExecutionStep = "precheck.target_running"
+	SubTargetReachable  ExecutionStep = "precheck.target_reachable"
+	SubMetricPortOpen   ExecutionStep = "precheck.metric_port_open"
+	SubRemoteCommand    ExecutionStep = "precheck.remote_command"
+	SubGeneratorPrecond ExecutionStep = "precheck.generator_precond"
+
+	// generator
+	SubGeneratorLookup    ExecutionStep = "generator_install.lookup"
+	SubGeneratorAlive     ExecutionStep = "generator_install.verify_alive"
+	SubGeneratorProvision ExecutionStep = "generator_install.provision"
+	SubGeneratorInstall   ExecutionStep = "generator_install.install"
+	SubGeneratorVerify    ExecutionStep = "generator_install.verify_install"
+
+	// target metric agent — installed, started and answering are three different things
+	SubAgentInstall ExecutionStep = "agent_install.install"
+	SubAgentProcess ExecutionStep = "agent_install.process_up"
+	SubAgentPort    ExecutionStep = "agent_install.port_reachable"
+
+	// plan
+	SubPlanGenerate ExecutionStep = "jmx_prepare.generate"
+	SubPlanTransfer ExecutionStep = "jmx_prepare.transfer"
+
+	// load
+	SubLoadStart  ExecutionStep = "jmeter_run.start"
+	SubLoadRampUp ExecutionStep = "jmeter_run.ramp_up"
+	SubLoadHold   ExecutionStep = "jmeter_run.hold"
+	SubLoadExit   ExecutionStep = "jmeter_run.exit"
+
+	// collect — per file, because one missing metric file used to fail the whole collection
+	SubFileResult  ExecutionStep = "result_fetch.file_result"
+	SubFileCpu     ExecutionStep = "result_fetch.file_cpu"
+	SubFileMemory  ExecutionStep = "result_fetch.file_memory"
+	SubFileDisk    ExecutionStep = "result_fetch.file_disk"
+	SubFileNetwork ExecutionStep = "result_fetch.file_network"
+	SubPersist     ExecutionStep = "result_fetch.persist"
+)
+
+// Parent returns the phase a sub-step belongs to, or "" for a phase itself.
+func (s ExecutionStep) Parent() ExecutionStep {
+	if i := strings.IndexByte(string(s), '.'); i > 0 {
+		return ExecutionStep(s[:i])
+	}
+	return ""
+}
 
 // StepStatus is the per-step lifecycle status (FR-MA2-PERF-007-08).
 type StepStatus string
@@ -143,8 +199,9 @@ const (
 )
 
 type IconCode string
+
 const (
-	Ok IconCode = "IC0001"
-	Fail IconCode = "IC0002"
+	Ok      IconCode = "IC0001"
+	Fail    IconCode = "IC0002"
 	Pending IconCode = "IC0003"
 )

--- a/internal/core/common/constant/constant.go
+++ b/internal/core/common/constant/constant.go
@@ -43,16 +43,18 @@ const (
 // it carries its own start and finish time (BAR-1553).
 const (
 	// precheck — answered in seconds, before anything is provisioned
-	SubTargetExists     ExecutionStep = "precheck.target_exists"
-	SubTargetRunning    ExecutionStep = "precheck.target_running"
-	SubTargetReachable  ExecutionStep = "precheck.target_reachable"
-	SubMetricPortOpen   ExecutionStep = "precheck.metric_port_open"
-	SubRemoteCommand    ExecutionStep = "precheck.remote_command"
-	SubGeneratorPrecond ExecutionStep = "precheck.generator_precond"
+	SubTargetExists    ExecutionStep = "precheck.target_exists"
+	SubTargetRunning   ExecutionStep = "precheck.target_running"
+	SubTargetReachable ExecutionStep = "precheck.target_reachable"
+	SubMetricPortOpen  ExecutionStep = "precheck.metric_port_open"
+	SubRemoteCommand   ExecutionStep = "precheck.remote_command"
 
 	// generator
-	SubGeneratorLookup    ExecutionStep = "generator_install.lookup"
-	SubGeneratorAlive     ExecutionStep = "generator_install.verify_alive"
+	SubGeneratorLookup ExecutionStep = "generator_install.lookup"
+	SubGeneratorAlive  ExecutionStep = "generator_install.verify_alive"
+	// Whether this cm-ant can still ssh to a reused generator. It belongs to the generator
+	// phase rather than the precheck, which runs before there is a generator record to check.
+	SubGeneratorReachable ExecutionStep = "generator_install.reachable"
 	SubGeneratorProvision ExecutionStep = "generator_install.provision"
 	SubGeneratorInstall   ExecutionStep = "generator_install.install"
 	SubGeneratorVerify    ExecutionStep = "generator_install.verify_install"

--- a/internal/core/load/dtos.go
+++ b/internal/core/load/dtos.go
@@ -181,6 +181,15 @@ type LoadTestExecutionStepResult struct {
 	FinishAt *time.Time             `json:"finishAt,omitempty"`
 	Message  string                 `json:"message,omitempty"`
 	Detail   string                 `json:"detail,omitempty"`
+
+	// ElapsedSec is how long this step has taken: the whole span once it is done, or how long
+	// it has been running so far. The console needs the running figure to tell a step that is
+	// slow from one that is stuck, and computing it here keeps every caller agreeing on it.
+	ElapsedSec int `json:"elapsedSec,omitempty"`
+
+	// Children are the sub-steps of a phase. Callers that only render the phases can ignore
+	// this field and see exactly what they saw before.
+	Children []LoadTestExecutionStepResult `json:"children,omitempty"`
 }
 
 type GetLoadTestExecutionStateParam struct {

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -111,8 +111,12 @@ func (s *stepRecorder) fail(name constant.ExecutionStep, message, detail string)
 	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepFailed, FinishAt: &now, Message: message, Detail: detail})
 }
 
+// skip marks a step as deliberately not run. It stamps a finish time like any other ending:
+// without one the step keeps reporting a growing elapsed figure, which reads as "still busy"
+// when it is in fact long done.
 func (s *stepRecorder) skip(name constant.ExecutionStep, message string) {
-	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepSkipped, Message: message})
+	now := time.Now()
+	s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepSkipped, FinishAt: &now, Message: message})
 }
 
 // generatorRunMu serializes load test runs. The load generator is a shared singleton
@@ -250,19 +254,12 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 	// Check the environment before building anything (BAR-1553). A missing target or a closed
 	// port is answered in seconds here, instead of surfacing minutes into a run.
 	precheckCtx, cancelPrecheck := context.WithTimeout(context.Background(), 2*time.Minute)
-	outcome, err := l.runPrecheck(precheckCtx, param, rec)
+	err := l.runPrecheck(precheckCtx, param, rec)
 	cancelPrecheck()
 	if err != nil {
 		failed(fmt.Sprintf("Precheck failed: %v", err), err)
 		return
 	}
-	if !outcome.MetricsReachable {
-		// Say it once, up front. Otherwise it shows up at the end as missing metric files,
-		// which reads like a collection failure rather than a closed port.
-		param.CollectAdditionalSystemMetrics = false
-		loadTestExecutionState.WithMetrics = false
-	}
-
 	if param.LoadGeneratorInstallInfoId == uint(0) {
 		log.Info().Msgf("No LoadGeneratorInstallInfoId provided, installing load generator...")
 		rec.begin(constant.StepGeneratorInstall, "Installing load generator")
@@ -676,31 +673,43 @@ func (l *LoadService) executeLoadTest(param RunLoadTestParam, loadGeneratorInsta
 	} else if installLocation == constant.Local {
 		log.Info().Msg("Local execute detected.")
 
+		// The remote path above records each step; this one recorded none, so a local run
+		// showed "jmx_prepare" and "jmeter_run" as pending from start to finish and gave no
+		// clue where it was. Both paths now report the same way.
+		rec.begin(constant.StepJmxPrepare, "Preparing test plan")
+
 		exist := utils.ExistCheck(loadGeneratorInstallPath)
 
 		if !exist {
+			rec.fail(constant.StepJmxPrepare, "Load generator missing", fmt.Sprintf("nothing installed at %s", loadGeneratorInstallPath))
 			return compileDuration, executionDuration, errors.New("load generator installaion is not validated")
 		}
 
 		outputFile, err := os.Create(fmt.Sprintf("%s/test_plan/%s.jmx", loadGeneratorInstallPath, loadTestKey))
 		if err != nil {
+			rec.fail(constant.StepJmxPrepare, "Test plan write failed", err.Error())
 			return compileDuration, executionDuration, err
 		}
 
 		err = parseTestPlanStructToString(outputFile, param, loadGeneratorInstallInfo)
 
 		if err != nil {
+			rec.fail(constant.StepJmxPrepare, "Test plan generation failed", err.Error())
 			return compileDuration, executionDuration, err
 		}
+		rec.ok(constant.StepJmxPrepare, "Test plan ready")
 
+		rec.begin(constant.StepJmeterRun, "Running load test")
 		jmeterTestCommand := generateJmeterExecutionCmd(loadGeneratorInstallPath, loadGeneratorInstallVersion, testPlanName, resultFileName)
 		compileDuration = utils.DurationString(start)
 
 		err = utils.InlineCmd(jmeterTestCommand)
 		executionDuration = utils.DurationString(start)
 		if err != nil {
+			rec.fail(constant.StepJmeterRun, "Load test failed", fmt.Sprintf("jmeter stopped unexpectedly: %v", err))
 			return compileDuration, executionDuration, fmt.Errorf("jmeter test stopped unexpectedly; %w", err)
 		}
+		rec.ok(constant.StepJmeterRun, "Load test finished")
 	}
 
 	return compileDuration, executionDuration, nil

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -45,6 +45,10 @@ var subStepSeq = map[constant.ExecutionStep]int{
 	constant.SubTargetReachable: 3,
 	constant.SubMetricPortOpen:  4,
 	constant.SubRemoteCommand:   5,
+
+	constant.SubAgentInstall: 1,
+	constant.SubAgentProcess: 2,
+	constant.SubAgentPort:    3,
 }
 
 // stepRecorder persists per-step progress of a running load test so the web console can show
@@ -391,8 +395,24 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 			return
 		}
 
-		rec.ok(constant.StepAgentInstall, "Monitoring agent installed")
-		log.Info().Msgf("metrics agent installed successfully for load test; %s %s %s", arg.NsId, arg.InfraId, arg.NodeIds)
+		rec.ok(constant.SubAgentInstall, "Monitoring agent files installed")
+
+		// Installed is not the same as running, and running is not the same as answering.
+		// The install call reports success as soon as the remote command returns, and the
+		// script behind it starts the agent with nohup and prints success either way — so a
+		// target with no agent process at all was reported as installed, and the run then
+		// spent 27 minutes waiting on a port that was never going to answer (BAR-1552).
+		if err := l.verifyMetricAgent(param, rec); err != nil {
+			// Losing metrics is not worth failing the run for. Say what happened, drop the
+			// metrics and carry on with the load figures.
+			param.CollectAdditionalSystemMetrics = false
+			loadTestExecutionState.WithMetrics = false
+			rec.skip(constant.StepAgentInstall, "Continuing without metrics - the agent is not answering")
+			log.Warn().Msgf("metric agent unavailable, continuing without metrics; %v", err)
+		} else {
+			rec.ok(constant.StepAgentInstall, "Monitoring agent installed")
+			log.Info().Msgf("metrics agent installed successfully for load test; %s %s %s", arg.NsId, arg.InfraId, arg.NodeIds)
+		}
 	} else {
 		rec.skip(constant.StepAgentInstall, "Additional metrics not collected")
 	}

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -46,6 +46,8 @@ var subStepSeq = map[constant.ExecutionStep]int{
 	constant.SubMetricPortOpen:  4,
 	constant.SubRemoteCommand:   5,
 
+	constant.SubGeneratorReachable: 1,
+
 	constant.SubAgentInstall: 1,
 	constant.SubAgentProcess: 2,
 	constant.SubAgentPort:    3,
@@ -289,6 +291,23 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 	loadGeneratorInstallInfo, err := l.loadRepo.GetValidLoadGeneratorInstallInfoByIdTx(context.Background(), param.LoadGeneratorInstallInfoId)
 	if err != nil {
 		failed(fmt.Sprintf("Error installing load generator: %v", err), err)
+		return
+	}
+
+	// A reused generator can be recorded as installed and still be unreachable, because the
+	// key that reaches it lives in this container rather than anywhere durable: replacing the
+	// container leaves every existing generator with an authorized key whose private half is
+	// gone. Nothing before the very end of the run notices - the load runs on the generator
+	// itself and only fetching the results needs ssh - so the run would spend its whole length
+	// to fail at collection.
+	//
+	// cb-tumblebug still holds the VM's own key, so the way back in is through it: regenerate
+	// the pair and have tumblebug put the new public half in place. That is also why the key
+	// is not worth persisting here - keeping a copy would mean owning its lifetime and its
+	// exposure, to save a step tumblebug can do on demand.
+	if err := l.ensureGeneratorReachable(loadGeneratorInstallInfo, rec); err != nil {
+		rec.fail(constant.StepGeneratorInstall, "Load generator unreachable", err.Error())
+		failed(fmt.Sprintf("load generator is not reachable and could not be recovered: %v", err), err)
 		return
 	}
 

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -29,11 +29,22 @@ func getResourceNames() (nsId, mciId, vmName, sshKeyBase string) {
 
 // stepSeq fixes the display order of the execution steps (FR-MA2-PERF-007-08).
 var stepSeq = map[constant.ExecutionStep]int{
-	constant.StepGeneratorInstall: 1,
-	constant.StepAgentInstall:     2,
-	constant.StepJmxPrepare:       3,
-	constant.StepJmeterRun:        4,
-	constant.StepResultFetch:      5,
+	constant.StepPrecheck:         1,
+	constant.StepGeneratorInstall: 2,
+	constant.StepAgentInstall:     3,
+	constant.StepJmxPrepare:       4,
+	constant.StepJmeterRun:        5,
+	constant.StepResultFetch:      6,
+}
+
+// subStepSeq orders the sub-steps within their phase. They are seeded alongside the phases so
+// the console can draw the whole tree from the first poll rather than watching rows appear.
+var subStepSeq = map[constant.ExecutionStep]int{
+	constant.SubTargetExists:    1,
+	constant.SubTargetRunning:   2,
+	constant.SubTargetReachable: 3,
+	constant.SubMetricPortOpen:  4,
+	constant.SubRemoteCommand:   5,
 }
 
 // stepRecorder persists per-step progress of a running load test so the web console can show
@@ -55,7 +66,11 @@ func (s *stepRecorder) upsert(step *LoadTestExecutionStep) {
 	}
 	step.LoadTestExecutionStateId = s.state.ID
 	step.LoadTestKey = s.state.LoadTestKey
-	step.Seq = stepSeq[step.Name]
+	if seq, ok := stepSeq[step.Name]; ok {
+		step.Seq = seq
+	} else {
+		step.Seq = subStepSeq[step.Name]
+	}
 	if err := s.l.loadRepo.UpsertLoadTestExecutionStepTx(context.Background(), step); err != nil {
 		log.Warn().Msgf("failed to record execution step %s; %v", step.Name, err)
 	}
@@ -64,6 +79,9 @@ func (s *stepRecorder) upsert(step *LoadTestExecutionStep) {
 // seed creates the full pipeline as pending so the web can render every step upfront.
 func (s *stepRecorder) seed() {
 	for name := range stepSeq {
+		s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepPending})
+	}
+	for name := range subStepSeq {
 		s.upsert(&LoadTestExecutionStep{Name: name, Status: constant.StepPending})
 	}
 }
@@ -223,6 +241,22 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		globalErr = occuredError
 		finishAt := time.Now()
 		loadTestExecutionState.FinishAt = &finishAt
+	}
+
+	// Check the environment before building anything (BAR-1553). A missing target or a closed
+	// port is answered in seconds here, instead of surfacing minutes into a run.
+	precheckCtx, cancelPrecheck := context.WithTimeout(context.Background(), 2*time.Minute)
+	outcome, err := l.runPrecheck(precheckCtx, param, rec)
+	cancelPrecheck()
+	if err != nil {
+		failed(fmt.Sprintf("Precheck failed: %v", err), err)
+		return
+	}
+	if !outcome.MetricsReachable {
+		// Say it once, up front. Otherwise it shows up at the end as missing metric files,
+		// which reads like a collection failure rather than a closed port.
+		param.CollectAdditionalSystemMetrics = false
+		loadTestExecutionState.WithMetrics = false
 	}
 
 	if param.LoadGeneratorInstallInfoId == uint(0) {

--- a/internal/core/load/performace_evaluation_service.go
+++ b/internal/core/load/performace_evaluation_service.go
@@ -173,19 +173,9 @@ func mapLoadTestExecutionStateResult(state LoadTestExecutionState) LoadTestExecu
 		stateResult.IconCode = constant.Pending
 	}
 
-	// FR-MA2-PERF-007-08: expose per-step progress.
-	for _, s := range state.Steps {
-		stateResult.Steps = append(stateResult.Steps, LoadTestExecutionStepResult{
-			Seq:      s.Seq,
-			Name:     s.Name,
-			Status:   s.Status,
-			Attempt:  s.Attempt,
-			StartAt:  s.StartAt,
-			FinishAt: s.FinishAt,
-			Message:  s.Message,
-			Detail:   s.Detail,
-		})
-	}
+	// FR-MA2-PERF-007-08: expose per-step progress. BAR-1553 nests the sub-steps under their
+	// phase and stamps each one with how long it has taken.
+	stateResult.Steps = buildStepTree(state.Steps, time.Now())
 
 	return *stateResult
 

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -361,9 +361,11 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 			"each round waited up to %s for the agent, checking every %s, and kept waiting only while the install was still running.\n"+
 			"the install script starts the agent with nohup and reports success either way, so reaching here means it did not stay up.\n"+
 			"check on the target that java is present, that %s holds the unpacked agent, and that nothing else is bound to port %s.\n"+
+			"the install script's own account of each round is in %s, with the phase it reached in %s.\n"+
 			"last error: %v",
 		param.NsId, param.InfraId, param.NodeId, agentInstallRounds,
-		strings.Join(attempts, "\n  "), agentUpCeiling, agentPollDelay, agentWorkDir, metricAgentPort, lastErr)
+		strings.Join(attempts, "\n  "), agentUpCeiling, agentPollDelay, agentWorkDir, metricAgentPort,
+		agentInstallLogFile, agentInstallStateFile, lastErr)
 	rec.fail(constant.SubAgentProcess, "Metric agent could not be started", detail)
 	if lastErr == nil {
 		lastErr = fmt.Errorf("metric agent did not come up")
@@ -383,6 +385,8 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 	var lastErr error
 	sawInstaller := false
 
+	started := time.Now()
+
 	for attempt := 1; ; attempt++ {
 		if err := l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId); err == nil {
 			return fmt.Sprintf("agent came up after %d checks", attempt), nil
@@ -390,30 +394,60 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 			lastErr = err
 		}
 
-		installing, err := l.probeAgentInstalling(ctx, param.NsId, param.InfraId, param.NodeId)
-		if err != nil {
-			// Not being able to ask is itself worth reporting, but it is not proof the install
-			// has stopped - keep waiting rather than reinstalling on a lost packet.
-			installing = true
-		}
+		installing, what := l.installProgress(ctx, param)
 		if !installing {
 			if sawInstaller {
-				return "the install finished but left no agent process", fmt.Errorf("install finished without leaving an agent: %w", lastErr)
+				return fmt.Sprintf("the install stopped at '%s' and left no agent process", what),
+					fmt.Errorf("install stopped at %s without leaving an agent: %w", what, lastErr)
 			}
-			return "no agent and no install running", fmt.Errorf("no agent process and no install in progress: %w", lastErr)
+			return fmt.Sprintf("no agent and no install running (%s)", what),
+				fmt.Errorf("no agent process and no install in progress: %w", lastErr)
 		}
 		sawInstaller = true
 
 		if time.Now().After(deadline) {
-			return fmt.Sprintf("install still running after %s", agentUpCeiling),
-				fmt.Errorf("install still running after %s without producing an agent: %w", agentUpCeiling, lastErr)
+			return fmt.Sprintf("still at '%s' after %s", what, agentUpCeiling),
+				fmt.Errorf("install still at %s after %s without producing an agent: %w", what, agentUpCeiling, lastErr)
 		}
 
+		// The phase is the point of this message. "45s elapsed" only says time is passing;
+		// "downloading the agent, 45s" says whether that is reasonable.
 		rec.progress(constant.SubAgentProcess, round,
-			fmt.Sprintf("Installing the agent (%ds elapsed)", int(agentUpCeiling.Seconds())-int(time.Until(deadline).Seconds())),
-			"the install is still running on the target")
+			fmt.Sprintf("Installing the agent - %s (%ds)", what, int(time.Since(started).Seconds())),
+			fmt.Sprintf("the install is still running on the target; waiting up to %s", agentUpCeiling))
 		time.Sleep(agentPollDelay)
 	}
+}
+
+// installProgress answers whether an install is still going, and what it is doing.
+//
+// The script's own marker is the first source, because it is the only one that can report a
+// failure: an install that died leaves no process, which is indistinguishable from one that
+// never started. Targets whose agent predates the marker have no file, and there the process
+// list is all there is - so it stays as a fallback rather than the primary answer.
+//
+// A target that cannot be asked at all is treated as still installing. A lost packet is not
+// evidence that the install stopped, and reinstalling on one would interrupt work in progress.
+func (l *LoadService) installProgress(ctx context.Context, param RunLoadTestParam) (bool, string) {
+	st, err := l.probeAgentInstallState(ctx, param.NsId, param.InfraId, param.NodeId)
+	if err != nil {
+		return true, "could not read the install state"
+	}
+	if st.Phase != "" {
+		if st.Phase == "failed" && st.Detail != "" {
+			return false, fmt.Sprintf("install failed: %s", st.Detail)
+		}
+		return st.Running(), st.Describe()
+	}
+
+	installing, err := l.probeAgentInstalling(ctx, param.NsId, param.InfraId, param.NodeId)
+	if err != nil {
+		return true, "could not read the process list"
+	}
+	if installing {
+		return true, "install running (no state recorded)"
+	}
+	return false, "no install recorded and nothing running"
 }
 
 const (
@@ -429,6 +463,11 @@ const (
 	agentInstallRounds = 2
 
 	agentWorkDir = "/opt/perfmon-agent"
+
+	// Written by script/install-server-agent.sh as it goes. Kept outside the agent directory
+	// so a failure before that directory exists is still recorded.
+	agentInstallStateFile = "/var/tmp/cm-ant-agent-install.state"
+	agentInstallLogFile   = "/var/tmp/cm-ant-agent-install.log"
 )
 
 // probeAgentProcess asks the target whether the agent process exists.
@@ -455,13 +494,91 @@ func (l *LoadService) probeAgentProcess(ctx context.Context, nsId, infraId, node
 	return nil
 }
 
-// probeAgentInstalling asks whether an install is still working on the target.
+// agentInstallState is what the install script last said about itself.
+type agentInstallState struct {
+	Phase  string // preparing, dependencies, downloading, unpacking, present, starting, started, failed
+	Detail string
+	Raw    string
+}
+
+// Running reports whether the install still has work in front of it. "started" is not running:
+// the script has done all it can and the agent either came up or did not.
+func (s agentInstallState) Running() bool {
+	switch s.Phase {
+	case "preparing", "dependencies", "downloading", "unpacking", "present", "starting":
+		return true
+	default:
+		return false
+	}
+}
+
+// Describe renders the phase for a step message - what the target is actually doing, rather
+// than a spinner that says only that time is passing.
+func (s agentInstallState) Describe() string {
+	switch s.Phase {
+	case "preparing":
+		return "preparing the target"
+	case "dependencies":
+		return "installing java and tools"
+	case "downloading":
+		return "downloading the agent"
+	case "unpacking":
+		return "unpacking the agent"
+	case "present":
+		return "agent already present"
+	case "starting":
+		return "starting the agent"
+	case "started":
+		return "agent start reported"
+	case "failed":
+		return "install failed"
+	case "":
+		return "no install recorded"
+	default:
+		return s.Phase
+	}
+}
+
+// probeAgentInstallState reads the marker the install script writes as it goes.
 //
-// This is what separates "give it more time" from "it is never going to finish". The install
-// spends nearly all of its time in apt fetching a JRE, then briefly in wget and unzip on the
-// agent release, and ends by starting the agent - so those are what it looks for. The dpkg
-// lock is included because an install blocked behind another package operation is still an
-// install in progress, and killing it would leave a half-configured target behind.
+// This is what separates "give it more time" from "it is never going to finish", and the
+// script saying so directly beats inferring it from the process list: an apt running on the
+// target is not necessarily ours, and a failed install leaves no process at all - it looks
+// exactly like one that never started. The script records a phase before each stage and
+// records "failed" from an ERR trap, so both of those become answers instead of guesses.
+//
+// A target whose agent was installed before this marker existed has no file. That is reported
+// as an empty phase rather than an error, and the caller falls back to the process list.
+func (l *LoadService) probeAgentInstallState(ctx context.Context, nsId, infraId, nodeId string) (agentInstallState, error) {
+	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
+		Command:  []string{fmt.Sprintf("cat %s 2>/dev/null || true", agentInstallStateFile)},
+		UserName: "cb-user",
+	})
+	if err != nil {
+		return agentInstallState{}, err
+	}
+
+	line := lastNonEmptyLine(res)
+	if line == "" {
+		return agentInstallState{}, nil
+	}
+
+	// timestamp \t phase \t detail
+	parts := strings.SplitN(line, "\t", 3)
+	st := agentInstallState{Raw: line}
+	if len(parts) > 1 {
+		st.Phase = strings.TrimSpace(parts[1])
+	}
+	if len(parts) > 2 {
+		st.Detail = strings.TrimSpace(parts[2])
+	}
+	return st, nil
+}
+
+// probeAgentInstalling falls back to the process list for targets whose install predates the
+// state marker. It looks for what the install actually spends its time on: apt fetching a JRE,
+// then the agent download and unpack, then the start script. The dpkg lock counts too, since
+// an install blocked behind another package operation is still an install in progress.
 func (l *LoadService) probeAgentInstalling(ctx context.Context, nsId, infraId, nodeId string) (bool, error) {
 	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
 		Command: []string{
@@ -476,6 +593,16 @@ func (l *LoadService) probeAgentInstalling(ctx context.Context, nsId, infraId, n
 		return false, err
 	}
 	return strings.Contains(res, "install-running"), nil
+}
+
+func lastNonEmptyLine(s string) string {
+	lines := strings.Split(strings.TrimSpace(s), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		if t := strings.TrimSpace(lines[i]); t != "" {
+			return t
+		}
+	}
+	return ""
 }
 
 // retryN is retry with the attempt count and delay supplied by the caller.

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -23,10 +23,22 @@ import (
 // run behaved, not about the environment it was given.
 
 const (
-	precheckDialTimeout   = 5 * time.Second
-	precheckHTTPTimeout   = 10 * time.Second
-	precheckRemoteTimeout = 30 * time.Second
-	metricAgentPort       = "5555"
+	precheckDialTimeout = 5 * time.Second
+	precheckHTTPTimeout = 10 * time.Second
+	// A working remote command answers in about a second, so waiting half a minute for one
+	// buys nothing and delays the very finding this check exists to deliver quickly. Ten
+	// seconds is ten times the normal round trip.
+	//
+	// Waiting longer would not help in the usual case either: after a node restarts, ssh often
+	// takes minutes to accept connections - more so on small instance types - so this is a
+	// "try again shortly" situation rather than something to sit through.
+	precheckRemoteTimeout = 10 * time.Second
+
+	// Attempts are spaced further apart than the other checks. Cutting a request short on our
+	// side does not stop cb-tumblebug working on it, so retrying immediately would stack
+	// requests against a service that is already struggling to answer.
+	remoteRetryDelay = 5 * time.Second
+	metricAgentPort  = "5555"
 
 	// A single failed attempt is not enough to call something closed. A healthy target answers
 	// immediately, so retrying costs almost nothing when things are fine, and it keeps a
@@ -158,13 +170,16 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	// remote command. If that does not work, every later step fails in a way that is much
 	// harder to read than this one line.
 	rec.begin(constant.SubRemoteCommand, "Running a test command on the target")
-	if err := retry(rec, constant.SubRemoteCommand, "Running a test command on the target", func() error {
-		return l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId)
-	}); err != nil {
+	if err := retryN(rec, constant.SubRemoteCommand, "Running a test command on the target",
+		precheckAttempts, remoteRetryDelay, func() error {
+			return l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId)
+		}); err != nil {
 		msg := "Remote command failed on the target"
 		rec.fail(constant.SubRemoteCommand, msg, fmt.Sprintf(
 			"asked cb-tumblebug to run 'echo' on ns=%s infra=%s node=%s as cb-user, %d times; last error: %v\n"+
-				"everything the run does to the target goes through this path, so it stops here",
+				"everything the run does to the target goes through this path, so it stops here\n"+
+				"if the node was started recently, ssh can take several minutes to accept connections - more so on small instance types - so try again shortly\n"+
+				"if it has been up a while, check that port 22 is open and that the address cb-tumblebug holds for the node still matches the one the provider shows (a stop and start changes it)",
 			param.NsId, param.InfraId, param.NodeId, precheckAttempts, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return fmt.Errorf("remote command failed: %w", err)

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -127,14 +127,22 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 		if err := retry(rec, constant.SubMetricPortOpen, "Checking the metric agent port", func() error {
 			return dial(vm.PublicIP, metricAgentPort)
 		}); err != nil {
-			// The short line goes on screen; the detail is what a hover reveals.
-			msg := fmt.Sprintf("Metric port %s closed", metricAgentPort)
+			// A refused connection and one that times out call for opposite fixes, and telling
+			// someone to open a port that is already open sends them looking in the wrong
+			// place. Refused means the host answered and nothing was listening - the agent is
+			// down. A timeout means nothing answered at all - the packets are being dropped.
+			msg := fmt.Sprintf("Metric port %s unreachable", metricAgentPort)
+			cause := fmt.Sprintf("Add %s inbound to the security group, then run the test again.", metricAgentPort)
+			if isConnectionRefused(err) {
+				msg = "Metric agent not running"
+				cause = "The port is reachable but nothing is listening, so the metric agent is not running on the target. Check java on the target and /opt/perfmon-agent."
+			}
 			detail := fmt.Sprintf(
-				"Metric port %s on %s is closed - add %s inbound to the security group, then run the test again.\n"+
-					"System metrics cannot be measured while it is closed.\n"+
+				"Could not reach the metric agent on %s:%s. %s\n"+
+					"System metrics cannot be measured until this is resolved.\n"+
 					"If system performance figures are not needed, clear 'Collect Additional System Metrics' in the load configuration and run again.\n"+
 					"(tried %d times with a %s timeout; last error: %v)",
-				metricAgentPort, vm.PublicIP, metricAgentPort, precheckAttempts, precheckDialTimeout, err)
+				vm.PublicIP, metricAgentPort, cause, precheckAttempts, precheckDialTimeout, err)
 			rec.fail(constant.SubMetricPortOpen, msg, detail)
 			rec.fail(constant.StepPrecheck, msg, detail)
 			return fmt.Errorf("metric agent port %s is not reachable: %w", metricAgentPort, err)
@@ -232,6 +240,13 @@ func portOf(reqs []RunLoadTestHttpParam) string {
 		return "?"
 	}
 	return reqs[0].Port
+}
+
+// isConnectionRefused reports whether the host answered and refused, as opposed to never
+// answering. The two mean different things: refused is a process that is not there, a timeout
+// is traffic that is not getting through.
+func isConnectionRefused(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "connection refused")
 }
 
 func dial(host, port string) error {

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -132,7 +132,7 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 			detail := fmt.Sprintf(
 				"Metric port %s on %s is closed - add %s inbound to the security group, then run the test again.\n"+
 					"System metrics cannot be measured while it is closed.\n"+
-					"To run without them, turn off additional system metrics in the load configuration.\n"+
+					"If system performance figures are not needed, clear 'Collect Additional System Metrics' in the load configuration and run again.\n"+
 					"(tried %d times with a %s timeout; last error: %v)",
 				metricAgentPort, vm.PublicIP, metricAgentPort, precheckAttempts, precheckDialTimeout, err)
 			rec.fail(constant.SubMetricPortOpen, msg, detail)

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -28,7 +28,33 @@ const (
 	precheckHTTPTimeout   = 10 * time.Second
 	precheckRemoteTimeout = 30 * time.Second
 	metricAgentPort       = "5555"
+
+	// A single failed attempt is not enough to call something closed. A healthy target answers
+	// immediately, so retrying costs almost nothing when things are fine, and it keeps a
+	// momentary network hiccup from being reported as a firewall problem. The attempt count
+	// goes into the step message, so a check that needed retries reads as a warning sign even
+	// when it eventually passes.
+	precheckAttempts   = 3
+	precheckRetryDelay = 2 * time.Second
 )
+
+// retry runs check until it passes, reporting each attempt so the console can show that
+// something needed more than one try. Only the latest state is kept, which is enough: seeing
+// "attempt 2" means the first one failed.
+func retry(rec *stepRecorder, step constant.ExecutionStep, what string, check func() error) error {
+	var err error
+	for attempt := 1; attempt <= precheckAttempts; attempt++ {
+		if attempt > 1 {
+			rec.progress(step, attempt, fmt.Sprintf("%s (attempt %d of %d)", what, attempt, precheckAttempts),
+				fmt.Sprintf("previous attempt failed: %v", err))
+			time.Sleep(precheckRetryDelay)
+		}
+		if err = check(); err == nil {
+			return nil
+		}
+	}
+	return err
+}
 
 // precheckOutcome carries what the run needs to know afterwards.
 type precheckOutcome struct {
@@ -68,8 +94,14 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	// load will hit, and a target that answers from here may still be unreachable from the
 	// generator. So the configured request is sent once, and the status code is kept.
 	rec.begin(constant.SubTargetReachable, "Sending a test request to the target")
-	if code, err := probeTarget(ctx, param.HttpReqs); err != nil {
-		msg := fmt.Sprintf("Cannot reach the target on port %s. Open the port in the security group, or check that the service is running.", portOf(param.HttpReqs))
+	var code int
+	err = retry(rec, constant.SubTargetReachable, "Sending a test request to the target", func() error {
+		var e error
+		code, e = probeTarget(ctx, param.HttpReqs)
+		return e
+	})
+	if err != nil {
+		msg := fmt.Sprintf("Cannot reach the target on port %s after %d attempts. Open the port in the security group, or check that the service is running.", portOf(param.HttpReqs), precheckAttempts)
 		rec.fail(constant.SubTargetReachable, msg, err.Error())
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return out, fmt.Errorf("target is not reachable: %w", err)
@@ -86,7 +118,9 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	// ── the metric agent port ───────────────────────────────────────────────────────────
 	if param.CollectAdditionalSystemMetrics {
 		rec.begin(constant.SubMetricPortOpen, "Checking the metric agent port")
-		if err := dial(vm.PublicIP, metricAgentPort); err != nil {
+		if err := retry(rec, constant.SubMetricPortOpen, "Checking the metric agent port", func() error {
+			return dial(vm.PublicIP, metricAgentPort)
+		}); err != nil {
 			out.MetricsReachable = false
 			msg := fmt.Sprintf("Metric port %s is closed, so the run continues without CPU and memory figures. Add %s inbound to the security group to collect them.", metricAgentPort, metricAgentPort)
 			// Not a failure: the load test itself is unaffected.
@@ -105,7 +139,9 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	// remote command. If that does not work, every later step fails in a way that is much
 	// harder to read than this one line.
 	rec.begin(constant.SubRemoteCommand, "Running a test command on the target")
-	if err := l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId); err != nil {
+	if err := retry(rec, constant.SubRemoteCommand, "Running a test command on the target", func() error {
+		return l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId)
+	}); err != nil {
 		msg := "Cannot run remote commands on the target node. Check SSH access and the node agent."
 		rec.fail(constant.SubRemoteCommand, msg, err.Error())
 		rec.fail(constant.StepPrecheck, msg, err.Error())
@@ -188,4 +224,71 @@ func (l *LoadService) probeRemoteCommand(ctx context.Context, nsId, infraId, nod
 		return fmt.Errorf("remote command returned without executing")
 	}
 	return nil
+}
+
+// verifyMetricAgent waits for the agent to actually be up rather than trusting the install
+// call, which returns as soon as the remote command does (BAR-1552).
+//
+// The agent is started with nohup, so there is a gap between the script returning and the
+// port accepting connections. Short repeated checks cover that gap; giving up after them is
+// what turns "never going to answer" into an answer, instead of a wait with no end.
+func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorder) error {
+	ctx, cancel := context.WithTimeout(context.Background(), agentVerifyTimeout)
+	defer cancel()
+
+	rec.begin(constant.SubAgentProcess, "Checking the agent process")
+	if err := retryN(rec, constant.SubAgentProcess, "Checking the agent process", agentVerifyAttempts, agentVerifyDelay, func() error {
+		return l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId)
+	}); err != nil {
+		rec.fail(constant.SubAgentProcess, "The metric agent is not running on the target", err.Error())
+		return err
+	}
+	rec.ok(constant.SubAgentProcess, "Agent process is running")
+
+	rec.begin(constant.SubAgentPort, "Waiting for the agent to answer")
+	if err := retryN(rec, constant.SubAgentPort, "Waiting for the agent to answer", agentVerifyAttempts, agentVerifyDelay, func() error {
+		return dial(param.AgentHostname, metricAgentPort)
+	}); err != nil {
+		rec.fail(constant.SubAgentPort, fmt.Sprintf("The metric agent is not answering on port %s", metricAgentPort), err.Error())
+		return err
+	}
+	rec.ok(constant.SubAgentPort, "Agent is answering")
+	return nil
+}
+
+const (
+	agentVerifyAttempts = 5
+	agentVerifyDelay    = 3 * time.Second
+	agentVerifyTimeout  = 60 * time.Second
+)
+
+// probeAgentProcess asks the target whether the agent process exists.
+func (l *LoadService) probeAgentProcess(ctx context.Context, nsId, infraId, nodeId string) error {
+	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
+		Command:  []string{"pgrep -f ServerAgent >/dev/null && echo agent-up || echo agent-down"},
+		UserName: "cb-user",
+	})
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(res, "agent-up") {
+		return fmt.Errorf("agent process not found on the target")
+	}
+	return nil
+}
+
+// retryN is retry with the attempt count and delay supplied by the caller.
+func retryN(rec *stepRecorder, step constant.ExecutionStep, what string, attempts int, delay time.Duration, check func() error) error {
+	var err error
+	for attempt := 1; attempt <= attempts; attempt++ {
+		if attempt > 1 {
+			rec.progress(step, attempt, fmt.Sprintf("%s (attempt %d of %d)", what, attempt, attempts),
+				fmt.Sprintf("previous attempt failed: %v", err))
+			time.Sleep(delay)
+		}
+		if err = check(); err == nil {
+			return nil
+		}
+	}
+	return err
 }

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -358,13 +358,13 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 
 	detail := fmt.Sprintf(
 		"the metric agent on ns=%s infra=%s node=%s did not come up after %d install rounds:\n  %s\n"+
-			"each round waited up to %s for the agent, checking every %s, and kept waiting only while the install was still running.\n"+
+			"each round waited up to %s for the agent, checking every %s, and gave up early if the install went %s without reporting anything new.\n"+
 			"the install script starts the agent with nohup and reports success either way, so reaching here means it did not stay up.\n"+
 			"check on the target that java is present, that %s holds the unpacked agent, and that nothing else is bound to port %s.\n"+
 			"the install script's own account of each round is in %s, with the phase it reached in %s.\n"+
 			"last error: %v",
 		param.NsId, param.InfraId, param.NodeId, agentInstallRounds,
-		strings.Join(attempts, "\n  "), agentUpCeiling, agentPollDelay, agentWorkDir, metricAgentPort,
+		strings.Join(attempts, "\n  "), agentUpCeiling, agentPollDelay, agentStallWindow, agentWorkDir, metricAgentPort,
 		agentInstallLogFile, agentInstallStateFile, lastErr)
 	rec.fail(constant.SubAgentProcess, "Metric agent could not be started", detail)
 	if lastErr == nil {
@@ -387,6 +387,13 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 
 	started := time.Now()
 
+	// What the install last said, and when it last said something new. A download over a bad
+	// link can legitimately run for minutes, so time alone cannot condemn it - but the script
+	// reports a figure that advances with the work, so a report that stops changing is the
+	// install stopping. That is what this pair watches.
+	lastReport := ""
+	lastMoved := time.Now()
+
 	for attempt := 1; ; attempt++ {
 		if err := l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId); err == nil {
 			return fmt.Sprintf("agent came up after %d checks", attempt), nil
@@ -394,7 +401,7 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 			lastErr = err
 		}
 
-		installing, what := l.installProgress(ctx, param)
+		st, installing, what := l.installProgress(ctx, param)
 		if !installing {
 			if sawInstaller {
 				return fmt.Sprintf("the install stopped at '%s' and left no agent process", what),
@@ -405,16 +412,32 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 		}
 		sawInstaller = true
 
+		// Only a real report counts as movement. A read that failed carries no Raw, and letting
+		// that reset the timer would mean a target we cannot reach never looks stalled.
+		if st.Raw != "" && st.Raw != lastReport {
+			lastReport = st.Raw
+			lastMoved = time.Now()
+		}
+
+		if stalled := time.Since(lastMoved); stalled > agentStallWindow {
+			return fmt.Sprintf("stuck at '%s' - no progress for %s", what, stalled.Round(time.Second)),
+				fmt.Errorf("install stopped moving at %s for %s: %w", what, stalled.Round(time.Second), lastErr)
+		}
+
 		if time.Now().After(deadline) {
 			return fmt.Sprintf("still at '%s' after %s", what, agentUpCeiling),
 				fmt.Errorf("install still at %s after %s without producing an agent: %w", what, agentUpCeiling, lastErr)
 		}
 
-		// The phase is the point of this message. "45s elapsed" only says time is passing;
-		// "downloading the agent, 45s" says whether that is reasonable.
-		rec.progress(constant.SubAgentProcess, round,
-			fmt.Sprintf("Installing the agent - %s (%ds)", what, int(time.Since(started).Seconds())),
-			fmt.Sprintf("the install is still running on the target; waiting up to %s", agentUpCeiling))
+		// What the install is doing is the point of this message. "45s elapsed" only says time
+		// is passing; "downloading the agent, 1.2MB, 45s" says whether that is reasonable.
+		msg := fmt.Sprintf("Installing the agent - %s (%ds)", what, int(time.Since(started).Seconds()))
+		if st.Detail != "" {
+			msg = fmt.Sprintf("Installing the agent - %s: %s (%ds)", what, st.Detail, int(time.Since(started).Seconds()))
+		}
+		rec.progress(constant.SubAgentProcess, round, msg, fmt.Sprintf(
+			"the install is still running on the target; waiting up to %s in total, and up to %s without visible progress",
+			agentUpCeiling, agentStallWindow))
 		time.Sleep(agentPollDelay)
 	}
 }
@@ -430,18 +453,20 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 // the install stopped, and reinstalling on either would interrupt work still in progress:
 // a target that cannot be asked (a lost packet), and a marker not yet written (the install was
 // issued moments ago and has not reached its first record). The ceiling ends both.
-func (l *LoadService) installProgress(ctx context.Context, param RunLoadTestParam) (bool, string) {
+func (l *LoadService) installProgress(ctx context.Context, param RunLoadTestParam) (agentInstallState, bool, string) {
 	st, err := l.probeAgentInstallState(ctx, param.NsId, param.InfraId, param.NodeId)
 	if err != nil {
-		return true, "could not read the install state"
+		// Raw is left empty on purpose: a failed read is not a report, and treating it as one
+		// would reset the stall timer every time the network hiccups.
+		return agentInstallState{}, true, "could not read the install state"
 	}
 	switch {
 	case st.Phase == "":
-		return true, "install has not reported yet"
+		return st, true, "install has not reported yet"
 	case st.Phase == "failed" && st.Detail != "":
-		return false, fmt.Sprintf("install failed: %s", st.Detail)
+		return st, false, fmt.Sprintf("install failed: %s", st.Detail)
 	default:
-		return st.Running(), st.Describe()
+		return st, st.Running(), st.Describe()
 	}
 }
 
@@ -449,11 +474,15 @@ const (
 	agentVerifyAttempts = 5
 	agentVerifyDelay    = 3 * time.Second
 
-	// A healthy install lands well inside this; the ceiling is here so an install that never
-	// finishes becomes an answer instead of an open-ended wait.
-	agentUpCeiling  = 2 * time.Minute
-	agentPollDelay  = 5 * time.Second
-	agentProbeGrace = 30 * time.Second
+	// A healthy install lands well inside this. The ceiling is generous because a download over
+	// a bad link can honestly take minutes, and cutting one off to reinstall would only start
+	// the same slow download again. What actually catches a dead install is the stall window:
+	// the script reports a figure that advances with the work, so a report that has not changed
+	// in this long has stopped, however much of the ceiling is left.
+	agentUpCeiling   = 5 * time.Minute
+	agentStallWindow = 90 * time.Second
+	agentPollDelay   = 5 * time.Second
+	agentProbeGrace  = 30 * time.Second
 
 	agentInstallRounds = 2
 

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
 	"github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug"
+	"github.com/cloud-barista/cm-ant/internal/utils"
 )
 
 // Checks that can be answered in seconds, run before anything is provisioned (BAR-1553).
@@ -598,6 +600,92 @@ func (l *LoadService) probeAgentInstallState(ctx context.Context, nsId, infraId,
 	}
 	return st, nil
 }
+
+// ensureGeneratorReachable makes sure this cm-ant can still ssh to a reused generator, and
+// puts it back through cb-tumblebug when it cannot.
+//
+// The private half of the generator's key lives in this container's home directory, which no
+// volume backs. Replacing the container - a new image, a restart onto a fresh filesystem -
+// destroys it while the generator VM keeps the matching authorized key and the database keeps
+// calling the generator installed. From then on the generator is unusable in a way that shows
+// up only at the very end: the load runs on the generator itself, so everything succeeds until
+// the results have to be fetched over ssh.
+//
+// Recovering through tumblebug rather than keeping a copy of the key is deliberate. Tumblebug
+// already holds the VM's own credentials, so it can place a new public key on demand; a copy
+// here would have to be stored somewhere durable, kept in step with the VM, and protected -
+// owning a secret's lifetime to save a step someone else can already do.
+func (l *LoadService) ensureGeneratorReachable(info LoadGeneratorInstallInfo, rec *stepRecorder) error {
+	if info.InstallLocation != constant.Remote || len(info.LoadGeneratorServers) == 0 {
+		return nil
+	}
+
+	server := info.LoadGeneratorServers[0]
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("could not resolve the home directory holding the generator key: %w", err)
+	}
+	keyPath := fmt.Sprintf("%s/.ssh/%s", home, info.PrivateKeyName)
+
+	if utils.ExistCheck(keyPath) && sshWorks(keyPath, server.Username, server.PublicIp) {
+		return nil
+	}
+
+	rec.begin(constant.SubGeneratorReachable, "Restoring access to the generator")
+
+	// Regenerates the pair when the private half is missing, and returns the command that puts
+	// the public half on the generator.
+	addAuthorizedKeyCommand, err := getAddAuthorizedKeyCommand(info.PrivateKeyName, info.PublicKeyName)
+	if err != nil {
+		rec.fail(constant.SubGeneratorReachable, "Could not prepare a new key for the generator", err.Error())
+		return fmt.Errorf("could not prepare a key for the generator: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), generatorRecoverTimeout)
+	defer cancel()
+
+	nsId, _, _, _ := getResourceNames()
+	mciName := info.MciName
+	if mciName == "" {
+		_, mciName, _, _ = getResourceNames()
+	}
+
+	if _, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, mciName, server.NodeId,
+		tumblebug.SendCommandReq{Command: []string{addAuthorizedKeyCommand}}); err != nil {
+		rec.fail(constant.SubGeneratorReachable, "Could not restore access to the generator", fmt.Sprintf(
+			"the key that reaches generator %s (%s) is gone from this cm-ant, and asking cb-tumblebug to install a new one failed: %v\n"+
+				"the generator is recorded as installed but cannot be used until this succeeds - the load would run and only the results would fail to arrive\n"+
+				"check that ns=%s mci=%s node=%s still exists and answers remote commands",
+			server.NodeId, server.PublicIp, err, nsId, mciName, server.NodeId))
+		return fmt.Errorf("could not restore access to the generator through cb-tumblebug: %w", err)
+	}
+
+	if !sshWorks(keyPath, server.Username, server.PublicIp) {
+		rec.fail(constant.SubGeneratorReachable, "Generator still unreachable after restoring the key", fmt.Sprintf(
+			"cb-tumblebug reported the new key was installed on %s (%s), but ssh with it still does not work\n"+
+				"check port 22 on the generator and whether %s is the right user for it",
+			server.NodeId, server.PublicIp, server.Username))
+		return fmt.Errorf("generator %s is still unreachable after installing a new key", server.PublicIp)
+	}
+
+	rec.ok(constant.SubGeneratorReachable, "Access to the generator restored")
+	return nil
+}
+
+// sshWorks reports whether the key opens a session on the generator. It runs the cheapest
+// thing that proves the whole path - the key, port 22, and the user - since that is exactly
+// what the result fetch will need later.
+func sshWorks(keyPath, username, host string) bool {
+	cmd := fmt.Sprintf(
+		`ssh -i %s -o StrictHostKeyChecking=no -o BatchMode=yes -o ConnectTimeout=%d %s@%s true`,
+		keyPath, int(generatorSSHTimeout.Seconds()), username, host)
+	return utils.InlineCmd(cmd) == nil
+}
+
+const (
+	generatorSSHTimeout     = 10 * time.Second
+	generatorRecoverTimeout = 2 * time.Minute
+)
 
 func lastNonEmptyLine(s string) string {
 	lines := strings.Split(strings.TrimSpace(s), "\n")

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -128,38 +128,41 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	// ── the metric agent port ───────────────────────────────────────────────────────────
 	//
 	// The charts are the point of a load test, and they are drawn from the metrics this port
-	// carries. A run that cannot collect them produces response times and nothing else, so it
-	// stops here and asks for the port to be opened rather than spending the time to arrive at
-	// the same place with less to show for it.
+	// carries. What this check settles is whether the port can carry them at all - that is,
+	// whether the security group lets the traffic through. Something already listening is not
+	// required, because installing the agent is the run's own next job.
 	//
-	// Once the port is open, a later failure is treated differently: by then the run is under
-	// way and the load figures are worth keeping (see verifyMetricAgent).
+	// The distinction is the whole point here. A dial that times out means the packets are
+	// being dropped, and no later step can undo that, so the run stops and asks for the port
+	// to be opened rather than spending several minutes arriving at the same place with less
+	// to show for it. A dial that is refused means the path is clear and nothing is listening
+	// yet - precisely the state a target is in before the agent is installed, and the state a
+	// target returns to when the agent dies. Stopping there would leave the run unable to do
+	// the one thing that would fix it, so it goes on and verifyMetricAgent judges the result
+	// once the install has actually had its turn.
 	if param.CollectAdditionalSystemMetrics {
 		rec.begin(constant.SubMetricPortOpen, "Checking the metric agent port")
-		if err := retry(rec, constant.SubMetricPortOpen, "Checking the metric agent port", func() error {
+		err := retry(rec, constant.SubMetricPortOpen, "Checking the metric agent port", func() error {
 			return dial(vm.PublicIP, metricAgentPort)
-		}); err != nil {
-			// A refused connection and one that times out call for opposite fixes, and telling
-			// someone to open a port that is already open sends them looking in the wrong
-			// place. Refused means the host answered and nothing was listening - the agent is
-			// down. A timeout means nothing answered at all - the packets are being dropped.
+		})
+		switch {
+		case err == nil:
+			rec.ok(constant.SubMetricPortOpen, "Metric agent port is reachable")
+		case isConnectionRefused(err):
+			rec.ok(constant.SubMetricPortOpen, "Metric agent port is open, agent not up yet")
+		default:
 			msg := fmt.Sprintf("Metric port %s unreachable", metricAgentPort)
-			cause := fmt.Sprintf("Add %s inbound to the security group, then run the test again.", metricAgentPort)
-			if isConnectionRefused(err) {
-				msg = "Metric agent not running"
-				cause = "The port is reachable but nothing is listening, so the metric agent is not running on the target. Check java on the target and /opt/perfmon-agent."
-			}
 			detail := fmt.Sprintf(
-				"Could not reach the metric agent on %s:%s. %s\n"+
-					"System metrics cannot be measured until this is resolved.\n"+
+				"Could not reach %s:%s, and nothing answered at all - the traffic is being dropped rather than refused.\n"+
+					"Add %s inbound to the security group, then run the test again.\n"+
+					"System metrics cannot be measured until this is resolved, and installing the agent will not help while the port is closed.\n"+
 					"If system performance figures are not needed, clear 'Collect Additional System Metrics' in the load configuration and run again.\n"+
 					"(tried %d times with a %s timeout; last error: %v)",
-				vm.PublicIP, metricAgentPort, cause, precheckAttempts, precheckDialTimeout, err)
+				vm.PublicIP, metricAgentPort, metricAgentPort, precheckAttempts, precheckDialTimeout, err)
 			rec.fail(constant.SubMetricPortOpen, msg, detail)
 			rec.fail(constant.StepPrecheck, msg, detail)
 			return fmt.Errorf("metric agent port %s is not reachable: %w", metricAgentPort, err)
 		}
-		rec.ok(constant.SubMetricPortOpen, "Metric agent port is reachable")
 	} else {
 		rec.skip(constant.SubMetricPortOpen, "Metrics not requested")
 	}
@@ -294,48 +297,138 @@ func (l *LoadService) probeRemoteCommand(ctx context.Context, nsId, infraId, nod
 	return nil
 }
 
-// verifyMetricAgent waits for the agent to actually be up rather than trusting the install
-// call, which returns as soon as the remote command does (BAR-1552).
+// verifyMetricAgent decides whether the agent is really up, and reinstalls it if it is not,
+// rather than trusting the install call - which returns as soon as the remote command does,
+// and reports success whether or not anything is left running (BAR-1552).
 //
-// The agent is started with nohup, so there is a gap between the script returning and the
-// port accepting connections. Short repeated checks cover that gap; giving up after them is
-// what turns "never going to answer" into an answer, instead of a wait with no end.
+// Waiting alone is not enough, because two very different things look the same from outside:
+// an install still working through apt and the agent zip, and an install that ended without
+// leaving an agent behind. The first only needs more time; the second will never resolve on
+// its own. So while the agent is missing this asks the target what is going on - if the
+// install is still running, it keeps waiting up to the ceiling; if nothing is running, there
+// is nothing to wait for and it goes straight to reinstalling.
+//
+// A reinstall gets one more round. Two rounds that both end without an agent are reported as
+// a failure with what was seen each time, since a third would only spend more of the run's
+// time arriving at the same answer.
 func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorder) error {
-	ctx, cancel := context.WithTimeout(context.Background(), agentVerifyTimeout)
+	rec.begin(constant.SubAgentProcess, "Checking the agent process")
+
+	var lastErr error
+	var attempts []string
+
+	for round := 1; round <= agentInstallRounds; round++ {
+		if round > 1 {
+			// The install script kills whatever holds the port before it starts, so running it
+			// again is the kill-and-reinstall - no separate teardown needed.
+			rec.progress(constant.SubAgentProcess, round,
+				fmt.Sprintf("Agent did not come up, reinstalling (round %d of %d)", round, agentInstallRounds),
+				fmt.Sprintf("previous round: %s", attempts[len(attempts)-1]))
+
+			arg := MonitoringAgentInstallationParams{NsId: param.NsId, InfraId: param.InfraId, NodeIds: []string{param.NodeId}}
+			if _, err := l.InstallMonitoringAgent(arg); err != nil {
+				lastErr = err
+				attempts = append(attempts, fmt.Sprintf("round %d: reinstall itself failed: %v", round, err))
+				continue
+			}
+		}
+
+		outcome, err := l.waitForAgentProcess(param, rec, round)
+		lastErr = err
+		attempts = append(attempts, fmt.Sprintf("round %d: %s", round, outcome))
+		if err != nil {
+			continue
+		}
+
+		rec.ok(constant.SubAgentProcess, "Agent process is running")
+
+		rec.begin(constant.SubAgentPort, "Waiting for the agent to answer")
+		if err := retryN(rec, constant.SubAgentPort, "Waiting for the agent to answer", agentVerifyAttempts, agentVerifyDelay, func() error {
+			return dial(param.AgentHostname, metricAgentPort)
+		}); err != nil {
+			lastErr = err
+			attempts = append(attempts, fmt.Sprintf("round %d: process up but nothing answered on %s: %v", round, metricAgentPort, err))
+			// The precheck already established that the port is not being filtered, so silence
+			// with a process up means the agent did not bind - which a reinstall can fix.
+			continue
+		}
+		rec.ok(constant.SubAgentPort, "Agent is answering")
+		return nil
+	}
+
+	detail := fmt.Sprintf(
+		"the metric agent on ns=%s infra=%s node=%s did not come up after %d install rounds:\n  %s\n"+
+			"each round waited up to %s for the agent, checking every %s, and kept waiting only while the install was still running.\n"+
+			"the install script starts the agent with nohup and reports success either way, so reaching here means it did not stay up.\n"+
+			"check on the target that java is present, that %s holds the unpacked agent, and that nothing else is bound to port %s.\n"+
+			"last error: %v",
+		param.NsId, param.InfraId, param.NodeId, agentInstallRounds,
+		strings.Join(attempts, "\n  "), agentUpCeiling, agentPollDelay, agentWorkDir, metricAgentPort, lastErr)
+	rec.fail(constant.SubAgentProcess, "Metric agent could not be started", detail)
+	if lastErr == nil {
+		lastErr = fmt.Errorf("metric agent did not come up")
+	}
+	return lastErr
+}
+
+// waitForAgentProcess waits for the agent process to appear, giving up early when there is
+// nothing left to wait for. It returns a sentence describing what it saw, for the failure
+// detail - a wait that ended because the install was still going says something different
+// from one that ended because nothing was running at all.
+func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecorder, round int) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), agentUpCeiling+agentProbeGrace)
 	defer cancel()
 
-	rec.begin(constant.SubAgentProcess, "Checking the agent process")
-	if err := retryN(rec, constant.SubAgentProcess, "Checking the agent process", agentVerifyAttempts, agentVerifyDelay, func() error {
-		return l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId)
-	}); err != nil {
-		rec.fail(constant.SubAgentProcess, "Metric agent not running", fmt.Sprintf(
-			"looked for a ServerAgent process on ns=%s infra=%s node=%s %d times over %s; last error: %v\n"+
-				"the install script starts the agent with nohup and reports success either way, so a failure here means it did not stay up - check java on the target and /opt/perfmon-agent",
-			param.NsId, param.InfraId, param.NodeId, agentVerifyAttempts,
-			agentVerifyDelay*time.Duration(agentVerifyAttempts-1), err))
-		return err
-	}
-	rec.ok(constant.SubAgentProcess, "Agent process is running")
+	deadline := time.Now().Add(agentUpCeiling)
+	var lastErr error
+	sawInstaller := false
 
-	rec.begin(constant.SubAgentPort, "Waiting for the agent to answer")
-	if err := retryN(rec, constant.SubAgentPort, "Waiting for the agent to answer", agentVerifyAttempts, agentVerifyDelay, func() error {
-		return dial(param.AgentHostname, metricAgentPort)
-	}); err != nil {
-		rec.fail(constant.SubAgentPort, fmt.Sprintf("Metric agent silent on port %s", metricAgentPort), fmt.Sprintf(
-			"the agent process is running on %s but nothing answered on port %s after %d attempts over %s; last error: %v\n"+
-				"the process being up rules out a failed start, so this is almost always the security group",
-			param.AgentHostname, metricAgentPort, agentVerifyAttempts,
-			agentVerifyDelay*time.Duration(agentVerifyAttempts-1), err))
-		return err
+	for attempt := 1; ; attempt++ {
+		if err := l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId); err == nil {
+			return fmt.Sprintf("agent came up after %d checks", attempt), nil
+		} else {
+			lastErr = err
+		}
+
+		installing, err := l.probeAgentInstalling(ctx, param.NsId, param.InfraId, param.NodeId)
+		if err != nil {
+			// Not being able to ask is itself worth reporting, but it is not proof the install
+			// has stopped - keep waiting rather than reinstalling on a lost packet.
+			installing = true
+		}
+		if !installing {
+			if sawInstaller {
+				return "the install finished but left no agent process", fmt.Errorf("install finished without leaving an agent: %w", lastErr)
+			}
+			return "no agent and no install running", fmt.Errorf("no agent process and no install in progress: %w", lastErr)
+		}
+		sawInstaller = true
+
+		if time.Now().After(deadline) {
+			return fmt.Sprintf("install still running after %s", agentUpCeiling),
+				fmt.Errorf("install still running after %s without producing an agent: %w", agentUpCeiling, lastErr)
+		}
+
+		rec.progress(constant.SubAgentProcess, round,
+			fmt.Sprintf("Installing the agent (%ds elapsed)", int(agentUpCeiling.Seconds())-int(time.Until(deadline).Seconds())),
+			"the install is still running on the target")
+		time.Sleep(agentPollDelay)
 	}
-	rec.ok(constant.SubAgentPort, "Agent is answering")
-	return nil
 }
 
 const (
 	agentVerifyAttempts = 5
 	agentVerifyDelay    = 3 * time.Second
-	agentVerifyTimeout  = 60 * time.Second
+
+	// A healthy install lands well inside this; the ceiling is here so an install that never
+	// finishes becomes an answer instead of an open-ended wait.
+	agentUpCeiling  = 2 * time.Minute
+	agentPollDelay  = 5 * time.Second
+	agentProbeGrace = 30 * time.Second
+
+	agentInstallRounds = 2
+
+	agentWorkDir = "/opt/perfmon-agent"
 )
 
 // probeAgentProcess asks the target whether the agent process exists.
@@ -360,6 +453,29 @@ func (l *LoadService) probeAgentProcess(ctx context.Context, nsId, infraId, node
 		return fmt.Errorf("agent process not found on the target")
 	}
 	return nil
+}
+
+// probeAgentInstalling asks whether an install is still working on the target.
+//
+// This is what separates "give it more time" from "it is never going to finish". The install
+// spends nearly all of its time in apt fetching a JRE, then briefly in wget and unzip on the
+// agent release, and ends by starting the agent - so those are what it looks for. The dpkg
+// lock is included because an install blocked behind another package operation is still an
+// install in progress, and killing it would leave a half-configured target behind.
+func (l *LoadService) probeAgentInstalling(ctx context.Context, nsId, infraId, nodeId string) (bool, error) {
+	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
+		Command: []string{
+			"if pgrep -f '[a]pt-get' >/dev/null || pgrep -f '[d]pkg' >/dev/null || " +
+				"pgrep -f '[w]get.*perfmon-agent' >/dev/null || pgrep -f '[u]nzip.*ServerAgent' >/dev/null || " +
+				"pgrep -f '[s]tartAgent.sh' >/dev/null || fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; " +
+				"then echo install-running; else echo install-idle; fi",
+		},
+		UserName: "cb-user",
+	})
+	if err != nil {
+		return false, err
+	}
+	return strings.Contains(res, "install-running"), nil
 }
 
 // retryN is retry with the attempt count and delay supplied by the caller.

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -179,7 +179,8 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 			"asked cb-tumblebug to run 'echo' on ns=%s infra=%s node=%s as cb-user, %d times; last error: %v\n"+
 				"everything the run does to the target goes through this path, so it stops here\n"+
 				"if the node was started recently, ssh can take several minutes to accept connections - more so on small instance types - so try again shortly\n"+
-				"if it has been up a while, check that port 22 is open and that the address cb-tumblebug holds for the node still matches the one the provider shows (a stop and start changes it)",
+				"if it has been up a while, check that port 22 is open and that the address cb-tumblebug holds for the node still matches the one the provider shows (a stop and start changes it)\n"+
+				"before running again, confirm you can reach port 22 yourself - a plain ssh from outside settles whether the security group, any other firewall in front of the node, and the ssh service itself are all in order",
 			param.NsId, param.InfraId, param.NodeId, precheckAttempts, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return fmt.Errorf("remote command failed: %w", err)

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -1,0 +1,191 @@
+package load
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+	"github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug"
+	"github.com/rs/zerolog/log"
+)
+
+// Checks that can be answered in seconds, run before anything is provisioned (BAR-1553).
+//
+// A run used to start by building a load generator, so a missing target or a closed port only
+// surfaced after minutes of work — in the worst case measured, 27 minutes went by before it
+// became clear the metric agent was unreachable. Everything below is cheap, so it goes first:
+// if the environment is wrong the run stops here and says what to fix.
+//
+// Passing this does not mean the run will succeed. It means a later failure is about how the
+// run behaved, not about the environment it was given.
+
+const (
+	precheckDialTimeout   = 5 * time.Second
+	precheckHTTPTimeout   = 10 * time.Second
+	precheckRemoteTimeout = 30 * time.Second
+	metricAgentPort       = "5555"
+)
+
+// precheckOutcome carries what the run needs to know afterwards.
+type precheckOutcome struct {
+	// MetricsReachable is false when the metric agent port is closed. The run continues —
+	// load figures are worth having without CPU and memory alongside them — but it is said
+	// up front rather than discovered as missing files at the end.
+	MetricsReachable bool
+}
+
+func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, rec *stepRecorder) (precheckOutcome, error) {
+	out := precheckOutcome{MetricsReachable: true}
+	rec.begin(constant.StepPrecheck, "Checking the environment")
+
+	// ── the target exists and is running ────────────────────────────────────────────────
+	rec.begin(constant.SubTargetExists, "Looking up the target node")
+	vm, err := l.tumblebugClient.GetVmWithContext(ctx, param.NsId, param.InfraId, param.NodeId)
+	if err != nil {
+		msg := "Target node not found. Check the namespace, infra and node ids."
+		rec.fail(constant.SubTargetExists, msg, err.Error())
+		rec.fail(constant.StepPrecheck, msg, err.Error())
+		return out, fmt.Errorf("target node not found: %w", err)
+	}
+	rec.ok(constant.SubTargetExists, "Target node found")
+
+	rec.begin(constant.SubTargetRunning, "Checking the target state")
+	if !strings.EqualFold(vm.Status, "Running") {
+		msg := fmt.Sprintf("Target node is not running (currently %s).", vm.Status)
+		rec.fail(constant.SubTargetRunning, msg, "")
+		rec.fail(constant.StepPrecheck, msg, "")
+		return out, fmt.Errorf("target node is not running: %s", vm.Status)
+	}
+	rec.ok(constant.SubTargetRunning, "Target node is running")
+
+	// ── the target answers the request the load will actually send ──────────────────────
+	//
+	// An open port only proves something is listening. It says nothing about the path the
+	// load will hit, and a target that answers from here may still be unreachable from the
+	// generator. So the configured request is sent once, and the status code is kept.
+	rec.begin(constant.SubTargetReachable, "Sending a test request to the target")
+	if code, err := probeTarget(ctx, param.HttpReqs); err != nil {
+		msg := fmt.Sprintf("Cannot reach the target on port %s. Open the port in the security group, or check that the service is running.", portOf(param.HttpReqs))
+		rec.fail(constant.SubTargetReachable, msg, err.Error())
+		rec.fail(constant.StepPrecheck, msg, err.Error())
+		return out, fmt.Errorf("target is not reachable: %w", err)
+	} else if code >= 400 {
+		// The target is alive but the path is not serving. Worth saying, not worth stopping
+		// for — the user may be load testing an endpoint that returns an error on purpose.
+		rec.progress(constant.SubTargetReachable, 0,
+			fmt.Sprintf("Target answered with status %d - check the request path", code), "")
+		rec.ok(constant.SubTargetReachable, fmt.Sprintf("Target answered with status %d", code))
+	} else {
+		rec.ok(constant.SubTargetReachable, fmt.Sprintf("Target answered with status %d", code))
+	}
+
+	// ── the metric agent port ───────────────────────────────────────────────────────────
+	if param.CollectAdditionalSystemMetrics {
+		rec.begin(constant.SubMetricPortOpen, "Checking the metric agent port")
+		if err := dial(vm.PublicIP, metricAgentPort); err != nil {
+			out.MetricsReachable = false
+			msg := fmt.Sprintf("Metric port %s is closed, so the run continues without CPU and memory figures. Add %s inbound to the security group to collect them.", metricAgentPort, metricAgentPort)
+			// Not a failure: the load test itself is unaffected.
+			rec.skip(constant.SubMetricPortOpen, msg)
+			log.Warn().Msgf("metric agent port unreachable on %s: %v", vm.PublicIP, err)
+		} else {
+			rec.ok(constant.SubMetricPortOpen, "Metric agent port is reachable")
+		}
+	} else {
+		rec.skip(constant.SubMetricPortOpen, "Metrics not requested")
+	}
+
+	// ── remote command actually round-trips ─────────────────────────────────────────────
+	//
+	// Everything the run does to the target and the generator goes through cb-tumblebug's
+	// remote command. If that does not work, every later step fails in a way that is much
+	// harder to read than this one line.
+	rec.begin(constant.SubRemoteCommand, "Running a test command on the target")
+	if err := l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId); err != nil {
+		msg := "Cannot run remote commands on the target node. Check SSH access and the node agent."
+		rec.fail(constant.SubRemoteCommand, msg, err.Error())
+		rec.fail(constant.StepPrecheck, msg, err.Error())
+		return out, fmt.Errorf("remote command failed: %w", err)
+	}
+	rec.ok(constant.SubRemoteCommand, "Remote command works")
+
+	rec.ok(constant.StepPrecheck, "Environment looks good")
+	return out, nil
+}
+
+// probeTarget sends the configured request once and returns the status code.
+func probeTarget(ctx context.Context, reqs []RunLoadTestHttpParam) (int, error) {
+	if len(reqs) == 0 {
+		return 0, fmt.Errorf("no http request configured")
+	}
+	r := reqs[0]
+
+	scheme := strings.ToLower(strings.TrimSpace(r.Protocol))
+	if scheme == "" {
+		scheme = "http"
+	}
+	path := r.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	url := fmt.Sprintf("%s://%s:%s%s", scheme, r.Hostname, r.Port, path)
+
+	method := strings.ToUpper(strings.TrimSpace(r.Method))
+	if method == "" {
+		method = http.MethodGet
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, precheckHTTPTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, method, url, nil)
+	if err != nil {
+		return 0, err
+	}
+	resp, err := (&http.Client{Timeout: precheckHTTPTimeout}).Do(req)
+	if err != nil {
+		return 0, err
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode, nil
+}
+
+func portOf(reqs []RunLoadTestHttpParam) string {
+	if len(reqs) == 0 {
+		return "?"
+	}
+	return reqs[0].Port
+}
+
+func dial(host, port string) error {
+	conn, err := net.DialTimeout("tcp", net.JoinHostPort(host, port), precheckDialTimeout)
+	if err != nil {
+		return err
+	}
+	return conn.Close()
+}
+
+// probeRemoteCommand runs a trivial command on the target and checks the answer comes back.
+func (l *LoadService) probeRemoteCommand(ctx context.Context, nsId, infraId, nodeId string) error {
+	ctx, cancel := context.WithTimeout(ctx, precheckRemoteTimeout)
+	defer cancel()
+
+	const marker = "cm-ant-precheck-ok"
+	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
+		Command:  []string{"echo " + marker},
+		UserName: "cb-user",
+	})
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(res, marker) {
+		// The call returned but the command did not run — the distinction the install path
+		// misses today, which is how an agent that never started was reported as installed.
+		return fmt.Errorf("remote command returned without executing")
+	}
+	return nil
+}

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -73,7 +73,9 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	vm, err := l.tumblebugClient.GetVmWithContext(ctx, param.NsId, param.InfraId, param.NodeId)
 	if err != nil {
 		msg := "Target node not found. Check the namespace, infra and node ids."
-		rec.fail(constant.SubTargetExists, msg, err.Error())
+		rec.fail(constant.SubTargetExists, msg, fmt.Sprintf(
+			"looked up ns=%s infra=%s node=%s in cb-tumblebug: %v",
+			param.NsId, param.InfraId, param.NodeId, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return out, fmt.Errorf("target node not found: %w", err)
 	}
@@ -82,7 +84,9 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	rec.begin(constant.SubTargetRunning, "Checking the target state")
 	if !strings.EqualFold(vm.Status, "Running") {
 		msg := fmt.Sprintf("Target node is not running (currently %s).", vm.Status)
-		rec.fail(constant.SubTargetRunning, msg, "")
+		rec.fail(constant.SubTargetRunning, msg, fmt.Sprintf(
+			"ns=%s infra=%s node=%s reported status %q; start the node before running a load test",
+			param.NsId, param.InfraId, param.NodeId, vm.Status))
 		rec.fail(constant.StepPrecheck, msg, "")
 		return out, fmt.Errorf("target node is not running: %s", vm.Status)
 	}
@@ -102,7 +106,11 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	})
 	if err != nil {
 		msg := fmt.Sprintf("Cannot reach the target on port %s after %d attempts. Open the port in the security group, or check that the service is running.", portOf(param.HttpReqs), precheckAttempts)
-		rec.fail(constant.SubTargetReachable, msg, err.Error())
+		rec.fail(constant.SubTargetReachable, msg, fmt.Sprintf(
+			"sent %s %s from cm-ant %d times over %s, each with a %s timeout; last error: %v\n"+
+				"check in this order: the service listens on the target, the security group allows inbound on that port, and the node has a reachable address",
+			methodOf(param.HttpReqs), targetURL(param.HttpReqs), precheckAttempts,
+			precheckRetryDelay*time.Duration(precheckAttempts-1), precheckHTTPTimeout, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return out, fmt.Errorf("target is not reachable: %w", err)
 	} else if code >= 400 {
@@ -122,7 +130,8 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 			return dial(vm.PublicIP, metricAgentPort)
 		}); err != nil {
 			out.MetricsReachable = false
-			msg := fmt.Sprintf("Metric port %s is closed, so the run continues without CPU and memory figures. Add %s inbound to the security group to collect them.", metricAgentPort, metricAgentPort)
+			msg := fmt.Sprintf("Metric port %s on %s is closed after %d attempts, so the run continues without CPU, memory, disk and network charts. Add %s inbound to the security group to collect them.",
+				metricAgentPort, vm.PublicIP, precheckAttempts, metricAgentPort)
 			// Not a failure: the load test itself is unaffected.
 			rec.skip(constant.SubMetricPortOpen, msg)
 			log.Warn().Msgf("metric agent port unreachable on %s: %v", vm.PublicIP, err)
@@ -143,7 +152,10 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 		return l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId)
 	}); err != nil {
 		msg := "Cannot run remote commands on the target node. Check SSH access and the node agent."
-		rec.fail(constant.SubRemoteCommand, msg, err.Error())
+		rec.fail(constant.SubRemoteCommand, msg, fmt.Sprintf(
+			"asked cb-tumblebug to run 'echo' on ns=%s infra=%s node=%s as cb-user, %d times; last error: %v\n"+
+				"everything the run does to the target goes through this path, so it stops here",
+			param.NsId, param.InfraId, param.NodeId, precheckAttempts, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
 		return out, fmt.Errorf("remote command failed: %w", err)
 	}
@@ -188,6 +200,29 @@ func probeTarget(ctx context.Context, reqs []RunLoadTestHttpParam) (int, error) 
 	}
 	defer resp.Body.Close()
 	return resp.StatusCode, nil
+}
+
+func targetURL(reqs []RunLoadTestHttpParam) string {
+	if len(reqs) == 0 {
+		return "(no request configured)"
+	}
+	r := reqs[0]
+	scheme := strings.ToLower(strings.TrimSpace(r.Protocol))
+	if scheme == "" {
+		scheme = "http"
+	}
+	path := r.Path
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return fmt.Sprintf("%s://%s:%s%s", scheme, r.Hostname, r.Port, path)
+}
+
+func methodOf(reqs []RunLoadTestHttpParam) string {
+	if len(reqs) == 0 || strings.TrimSpace(reqs[0].Method) == "" {
+		return "GET"
+	}
+	return strings.ToUpper(strings.TrimSpace(reqs[0].Method))
 }
 
 func portOf(reqs []RunLoadTestHttpParam) string {
@@ -240,7 +275,11 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 	if err := retryN(rec, constant.SubAgentProcess, "Checking the agent process", agentVerifyAttempts, agentVerifyDelay, func() error {
 		return l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId)
 	}); err != nil {
-		rec.fail(constant.SubAgentProcess, "The metric agent is not running on the target", err.Error())
+		rec.fail(constant.SubAgentProcess, "The metric agent is not running on the target", fmt.Sprintf(
+			"looked for a ServerAgent process on ns=%s infra=%s node=%s %d times over %s; last error: %v\n"+
+				"the install script starts the agent with nohup and reports success either way, so a failure here means it did not stay up - check java on the target and /opt/perfmon-agent",
+			param.NsId, param.InfraId, param.NodeId, agentVerifyAttempts,
+			agentVerifyDelay*time.Duration(agentVerifyAttempts-1), err))
 		return err
 	}
 	rec.ok(constant.SubAgentProcess, "Agent process is running")
@@ -249,7 +288,11 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 	if err := retryN(rec, constant.SubAgentPort, "Waiting for the agent to answer", agentVerifyAttempts, agentVerifyDelay, func() error {
 		return dial(param.AgentHostname, metricAgentPort)
 	}); err != nil {
-		rec.fail(constant.SubAgentPort, fmt.Sprintf("The metric agent is not answering on port %s", metricAgentPort), err.Error())
+		rec.fail(constant.SubAgentPort, fmt.Sprintf("The metric agent is not answering on port %s", metricAgentPort), fmt.Sprintf(
+			"the agent process is running on %s but nothing answered on port %s after %d attempts over %s; last error: %v\n"+
+				"the process being up rules out a failed start, so this is almost always the security group",
+			param.AgentHostname, metricAgentPort, agentVerifyAttempts,
+			agentVerifyDelay*time.Duration(agentVerifyAttempts-1), err))
 		return err
 	}
 	rec.ok(constant.SubAgentPort, "Agent is answering")

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -421,33 +421,28 @@ func (l *LoadService) waitForAgentProcess(param RunLoadTestParam, rec *stepRecor
 
 // installProgress answers whether an install is still going, and what it is doing.
 //
-// The script's own marker is the first source, because it is the only one that can report a
-// failure: an install that died leaves no process, which is indistinguishable from one that
-// never started. Targets whose agent predates the marker have no file, and there the process
-// list is all there is - so it stays as a fallback rather than the primary answer.
+// The script's marker is the only source, and it can be, because the script ships with cm-ant
+// and every install runs the current one. It is also the only source that can report a
+// failure: an install that died leaves no process, which from outside is indistinguishable
+// from one that never started.
 //
-// A target that cannot be asked at all is treated as still installing. A lost packet is not
-// evidence that the install stopped, and reinstalling on one would interrupt work in progress.
+// Two states mean "wait" rather than "give up", for the same reason - neither is evidence that
+// the install stopped, and reinstalling on either would interrupt work still in progress:
+// a target that cannot be asked (a lost packet), and a marker not yet written (the install was
+// issued moments ago and has not reached its first record). The ceiling ends both.
 func (l *LoadService) installProgress(ctx context.Context, param RunLoadTestParam) (bool, string) {
 	st, err := l.probeAgentInstallState(ctx, param.NsId, param.InfraId, param.NodeId)
 	if err != nil {
 		return true, "could not read the install state"
 	}
-	if st.Phase != "" {
-		if st.Phase == "failed" && st.Detail != "" {
-			return false, fmt.Sprintf("install failed: %s", st.Detail)
-		}
+	switch {
+	case st.Phase == "":
+		return true, "install has not reported yet"
+	case st.Phase == "failed" && st.Detail != "":
+		return false, fmt.Sprintf("install failed: %s", st.Detail)
+	default:
 		return st.Running(), st.Describe()
 	}
-
-	installing, err := l.probeAgentInstalling(ctx, param.NsId, param.InfraId, param.NodeId)
-	if err != nil {
-		return true, "could not read the process list"
-	}
-	if installing {
-		return true, "install running (no state recorded)"
-	}
-	return false, "no install recorded and nothing running"
 }
 
 const (
@@ -547,8 +542,8 @@ func (s agentInstallState) Describe() string {
 // exactly like one that never started. The script records a phase before each stage and
 // records "failed" from an ERR trap, so both of those become answers instead of guesses.
 //
-// A target whose agent was installed before this marker existed has no file. That is reported
-// as an empty phase rather than an error, and the caller falls back to the process list.
+// No file yet is reported as an empty phase rather than an error: the install was issued
+// moments ago and has not reached its first record.
 func (l *LoadService) probeAgentInstallState(ctx context.Context, nsId, infraId, nodeId string) (agentInstallState, error) {
 	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
 		Command:  []string{fmt.Sprintf("cat %s 2>/dev/null || true", agentInstallStateFile)},
@@ -573,26 +568,6 @@ func (l *LoadService) probeAgentInstallState(ctx context.Context, nsId, infraId,
 		st.Detail = strings.TrimSpace(parts[2])
 	}
 	return st, nil
-}
-
-// probeAgentInstalling falls back to the process list for targets whose install predates the
-// state marker. It looks for what the install actually spends its time on: apt fetching a JRE,
-// then the agent download and unpack, then the start script. The dpkg lock counts too, since
-// an install blocked behind another package operation is still an install in progress.
-func (l *LoadService) probeAgentInstalling(ctx context.Context, nsId, infraId, nodeId string) (bool, error) {
-	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
-		Command: []string{
-			"if pgrep -f '[a]pt-get' >/dev/null || pgrep -f '[d]pkg' >/dev/null || " +
-				"pgrep -f '[w]get.*perfmon-agent' >/dev/null || pgrep -f '[u]nzip.*ServerAgent' >/dev/null || " +
-				"pgrep -f '[s]tartAgent.sh' >/dev/null || fuser /var/lib/dpkg/lock-frontend >/dev/null 2>&1; " +
-				"then echo install-running; else echo install-idle; fi",
-		},
-		UserName: "cb-user",
-	})
-	if err != nil {
-		return false, err
-	}
-	return strings.Contains(res, "install-running"), nil
 }
 
 func lastNonEmptyLine(s string) string {

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
 	"github.com/cloud-barista/cm-ant/internal/infra/outbound/tumblebug"
-	"github.com/rs/zerolog/log"
 )
 
 // Checks that can be answered in seconds, run before anything is provisioned (BAR-1553).
@@ -56,39 +55,30 @@ func retry(rec *stepRecorder, step constant.ExecutionStep, what string, check fu
 	return err
 }
 
-// precheckOutcome carries what the run needs to know afterwards.
-type precheckOutcome struct {
-	// MetricsReachable is false when the metric agent port is closed. The run continues —
-	// load figures are worth having without CPU and memory alongside them — but it is said
-	// up front rather than discovered as missing files at the end.
-	MetricsReachable bool
-}
-
-func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, rec *stepRecorder) (precheckOutcome, error) {
-	out := precheckOutcome{MetricsReachable: true}
+func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, rec *stepRecorder) error {
 	rec.begin(constant.StepPrecheck, "Checking the environment")
 
 	// ── the target exists and is running ────────────────────────────────────────────────
 	rec.begin(constant.SubTargetExists, "Looking up the target node")
 	vm, err := l.tumblebugClient.GetVmWithContext(ctx, param.NsId, param.InfraId, param.NodeId)
 	if err != nil {
-		msg := "Target node not found. Check the namespace, infra and node ids."
+		msg := "Target node not found"
 		rec.fail(constant.SubTargetExists, msg, fmt.Sprintf(
 			"looked up ns=%s infra=%s node=%s in cb-tumblebug: %v",
 			param.NsId, param.InfraId, param.NodeId, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
-		return out, fmt.Errorf("target node not found: %w", err)
+		return fmt.Errorf("target node not found: %w", err)
 	}
 	rec.ok(constant.SubTargetExists, "Target node found")
 
 	rec.begin(constant.SubTargetRunning, "Checking the target state")
 	if !strings.EqualFold(vm.Status, "Running") {
-		msg := fmt.Sprintf("Target node is not running (currently %s).", vm.Status)
+		msg := fmt.Sprintf("Target node is %s, not running", vm.Status)
 		rec.fail(constant.SubTargetRunning, msg, fmt.Sprintf(
 			"ns=%s infra=%s node=%s reported status %q; start the node before running a load test",
 			param.NsId, param.InfraId, param.NodeId, vm.Status))
 		rec.fail(constant.StepPrecheck, msg, "")
-		return out, fmt.Errorf("target node is not running: %s", vm.Status)
+		return fmt.Errorf("target node is not running: %s", vm.Status)
 	}
 	rec.ok(constant.SubTargetRunning, "Target node is running")
 
@@ -105,14 +95,14 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 		return e
 	})
 	if err != nil {
-		msg := fmt.Sprintf("Cannot reach the target on port %s after %d attempts. Open the port in the security group, or check that the service is running.", portOf(param.HttpReqs), precheckAttempts)
+		msg := fmt.Sprintf("Target port %s unreachable", portOf(param.HttpReqs))
 		rec.fail(constant.SubTargetReachable, msg, fmt.Sprintf(
 			"sent %s %s from cm-ant %d times over %s, each with a %s timeout; last error: %v\n"+
 				"check in this order: the service listens on the target, the security group allows inbound on that port, and the node has a reachable address",
 			methodOf(param.HttpReqs), targetURL(param.HttpReqs), precheckAttempts,
 			precheckRetryDelay*time.Duration(precheckAttempts-1), precheckHTTPTimeout, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
-		return out, fmt.Errorf("target is not reachable: %w", err)
+		return fmt.Errorf("target is not reachable: %w", err)
 	} else if code >= 400 {
 		// The target is alive but the path is not serving. Worth saying, not worth stopping
 		// for — the user may be load testing an endpoint that returns an error on purpose.
@@ -124,20 +114,32 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	}
 
 	// ── the metric agent port ───────────────────────────────────────────────────────────
+	//
+	// The charts are the point of a load test, and they are drawn from the metrics this port
+	// carries. A run that cannot collect them produces response times and nothing else, so it
+	// stops here and asks for the port to be opened rather than spending the time to arrive at
+	// the same place with less to show for it.
+	//
+	// Once the port is open, a later failure is treated differently: by then the run is under
+	// way and the load figures are worth keeping (see verifyMetricAgent).
 	if param.CollectAdditionalSystemMetrics {
 		rec.begin(constant.SubMetricPortOpen, "Checking the metric agent port")
 		if err := retry(rec, constant.SubMetricPortOpen, "Checking the metric agent port", func() error {
 			return dial(vm.PublicIP, metricAgentPort)
 		}); err != nil {
-			out.MetricsReachable = false
-			msg := fmt.Sprintf("Metric port %s on %s is closed after %d attempts, so the run continues without CPU, memory, disk and network charts. Add %s inbound to the security group to collect them.",
-				metricAgentPort, vm.PublicIP, precheckAttempts, metricAgentPort)
-			// Not a failure: the load test itself is unaffected.
-			rec.skip(constant.SubMetricPortOpen, msg)
-			log.Warn().Msgf("metric agent port unreachable on %s: %v", vm.PublicIP, err)
-		} else {
-			rec.ok(constant.SubMetricPortOpen, "Metric agent port is reachable")
+			// The short line goes on screen; the detail is what a hover reveals.
+			msg := fmt.Sprintf("Metric port %s closed", metricAgentPort)
+			detail := fmt.Sprintf(
+				"Metric port %s on %s is closed - add %s inbound to the security group, then run the test again.\n"+
+					"System metrics cannot be measured while it is closed.\n"+
+					"To run without them, turn off additional system metrics in the load configuration.\n"+
+					"(tried %d times with a %s timeout; last error: %v)",
+				metricAgentPort, vm.PublicIP, metricAgentPort, precheckAttempts, precheckDialTimeout, err)
+			rec.fail(constant.SubMetricPortOpen, msg, detail)
+			rec.fail(constant.StepPrecheck, msg, detail)
+			return fmt.Errorf("metric agent port %s is not reachable: %w", metricAgentPort, err)
 		}
+		rec.ok(constant.SubMetricPortOpen, "Metric agent port is reachable")
 	} else {
 		rec.skip(constant.SubMetricPortOpen, "Metrics not requested")
 	}
@@ -151,18 +153,18 @@ func (l *LoadService) runPrecheck(ctx context.Context, param RunLoadTestParam, r
 	if err := retry(rec, constant.SubRemoteCommand, "Running a test command on the target", func() error {
 		return l.probeRemoteCommand(ctx, param.NsId, param.InfraId, param.NodeId)
 	}); err != nil {
-		msg := "Cannot run remote commands on the target node. Check SSH access and the node agent."
+		msg := "Remote command failed on the target"
 		rec.fail(constant.SubRemoteCommand, msg, fmt.Sprintf(
 			"asked cb-tumblebug to run 'echo' on ns=%s infra=%s node=%s as cb-user, %d times; last error: %v\n"+
 				"everything the run does to the target goes through this path, so it stops here",
 			param.NsId, param.InfraId, param.NodeId, precheckAttempts, err))
 		rec.fail(constant.StepPrecheck, msg, err.Error())
-		return out, fmt.Errorf("remote command failed: %w", err)
+		return fmt.Errorf("remote command failed: %w", err)
 	}
 	rec.ok(constant.SubRemoteCommand, "Remote command works")
 
 	rec.ok(constant.StepPrecheck, "Environment looks good")
-	return out, nil
+	return nil
 }
 
 // probeTarget sends the configured request once and returns the status code.
@@ -275,7 +277,7 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 	if err := retryN(rec, constant.SubAgentProcess, "Checking the agent process", agentVerifyAttempts, agentVerifyDelay, func() error {
 		return l.probeAgentProcess(ctx, param.NsId, param.InfraId, param.NodeId)
 	}); err != nil {
-		rec.fail(constant.SubAgentProcess, "The metric agent is not running on the target", fmt.Sprintf(
+		rec.fail(constant.SubAgentProcess, "Metric agent not running", fmt.Sprintf(
 			"looked for a ServerAgent process on ns=%s infra=%s node=%s %d times over %s; last error: %v\n"+
 				"the install script starts the agent with nohup and reports success either way, so a failure here means it did not stay up - check java on the target and /opt/perfmon-agent",
 			param.NsId, param.InfraId, param.NodeId, agentVerifyAttempts,
@@ -288,7 +290,7 @@ func (l *LoadService) verifyMetricAgent(param RunLoadTestParam, rec *stepRecorde
 	if err := retryN(rec, constant.SubAgentPort, "Waiting for the agent to answer", agentVerifyAttempts, agentVerifyDelay, func() error {
 		return dial(param.AgentHostname, metricAgentPort)
 	}); err != nil {
-		rec.fail(constant.SubAgentPort, fmt.Sprintf("The metric agent is not answering on port %s", metricAgentPort), fmt.Sprintf(
+		rec.fail(constant.SubAgentPort, fmt.Sprintf("Metric agent silent on port %s", metricAgentPort), fmt.Sprintf(
 			"the agent process is running on %s but nothing answered on port %s after %d attempts over %s; last error: %v\n"+
 				"the process being up rules out a failed start, so this is almost always the security group",
 			param.AgentHostname, metricAgentPort, agentVerifyAttempts,

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -308,9 +308,18 @@ const (
 )
 
 // probeAgentProcess asks the target whether the agent process exists.
+//
+// The pattern matches how the agent actually appears in the process list, which is not what
+// its name suggests: the release is distributed as ServerAgent-x.y.z.zip but runs as
+//
+//	java -jar /opt/perfmon-agent/CMDRunner.jar --tool PerfMonAgent --udp-port 0 --tcp-port 5555
+//
+// Looking for "ServerAgent" finds nothing on a target where the agent is running perfectly
+// well - a check that is wrong in the direction that matters, since it reports a healthy
+// agent as missing. The bracket keeps pgrep from matching the command carrying the pattern.
 func (l *LoadService) probeAgentProcess(ctx context.Context, nsId, infraId, nodeId string) error {
 	res, err := l.tumblebugClient.CommandToVmWithContext(ctx, nsId, infraId, nodeId, tumblebug.SendCommandReq{
-		Command:  []string{"pgrep -f ServerAgent >/dev/null && echo agent-up || echo agent-down"},
+		Command:  []string{"pgrep -f '[P]erfMonAgent' >/dev/null && echo agent-up || echo agent-down"},
 		UserName: "cb-user",
 	})
 	if err != nil {

--- a/internal/core/load/precheck.go
+++ b/internal/core/load/precheck.go
@@ -627,7 +627,11 @@ func (l *LoadService) ensureGeneratorReachable(info LoadGeneratorInstallInfo, re
 	}
 	keyPath := fmt.Sprintf("%s/.ssh/%s", home, info.PrivateKeyName)
 
+	// Recorded either way. Leaving the healthy case silent left a pending sub-step sitting under
+	// a finished phase, which reads as work that never happened rather than a check that passed.
+	rec.begin(constant.SubGeneratorReachable, "Checking access to the generator")
 	if utils.ExistCheck(keyPath) && sshWorks(keyPath, server.Username, server.PublicIp) {
+		rec.ok(constant.SubGeneratorReachable, "Generator is reachable")
 		return nil
 	}
 

--- a/internal/core/load/rsync_fetch_service.go
+++ b/internal/core/load/rsync_fetch_service.go
@@ -2,7 +2,8 @@ package load
 
 import (
 	"fmt"
-
+	"sort"
+	"strings"
 	"sync"
 	"time"
 
@@ -59,7 +60,7 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 		case <-ticker.C:
 			if !f.isRunning() {
 				f.setFetchRunning(true)
-				if err := rsyncFiles(f); err != nil {
+				if _, err := rsyncFiles(f); err != nil {
 					log.Error().Msgf("error while fetching data from rsync %s", err.Error())
 				}
 				f.setFetchRunning(false)
@@ -71,9 +72,10 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 			f.StepRec.begin(constant.StepResultFetch, "Collecting results")
 			retry := config.AppConfig.Load.Retry
 			var fetchErr error
+			var outcome fetchOutcome
 			for retry > 0 {
 				if !f.isRunning() {
-					fetchErr = rsyncFiles(f)
+					outcome, fetchErr = rsyncFiles(f)
 					if fetchErr != nil {
 						log.Error().Msgf("error while fetching data from rsync %s", fetchErr.Error())
 					}
@@ -83,9 +85,15 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 				retry--
 			}
 
-			if fetchErr != nil {
+			switch {
+			case fetchErr != nil:
 				f.StepRec.fail(constant.StepResultFetch, "Result collection failed", fmt.Sprintf("the load test finished but collecting the result files (rsync) failed: %v", fetchErr))
-			} else {
+			case len(outcome.MissingMetrics) > 0:
+				// The run stands on its own load figures. Say which charts will be empty and
+				// why, so an empty chart is not read as "the load produced nothing".
+				msg := fmt.Sprintf("Results collected, without %s metrics", strings.Join(outcome.MissingMetrics, ", "))
+				f.StepRec.ok(constant.StepResultFetch, msg)
+			default:
 				f.StepRec.ok(constant.StepResultFetch, "Results collected")
 			}
 
@@ -94,7 +102,21 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 	}
 }
 
-func rsyncFiles(f *fetchDataParam) error {
+// fetchOutcome says which result files made it across. The distinction matters: the load
+// figures come from the main file, while the cpu/disk/memory/network files are metrics
+// gathered alongside. Losing a metric file costs a chart; losing the main file costs the run.
+type fetchOutcome struct {
+	MissingMetrics []string // "cpu", "network", ... — collected but not retrievable
+}
+
+// rsyncFiles pulls the result files from the generator. It fails only when the main result is
+// missing; metric files that did not arrive are reported instead, so a run whose load figures
+// are intact is not thrown away for want of a network chart (BAR-1552).
+//
+// Metric files also tend to land later than the main one, so what looks missing now often
+// arrives on a later pass — hence the retries here and the periodic fetch above.
+func rsyncFiles(f *fetchDataParam) (fetchOutcome, error) {
+	var outcome fetchOutcome
 	loadTestKey := f.LoadTestKey
 	installLocation := f.InstallLocation
 	loadGeneratorInstallPath := f.InstallPath
@@ -106,18 +128,22 @@ func rsyncFiles(f *fetchDataParam) error {
 		resultsPrefix = append(resultsPrefix, "_cpu", "_disk", "_memory", "_network")
 	}
 
-	errorChan := make(chan error, len(resultsPrefix))
+	type fileResult struct {
+		prefix string
+		err    error
+	}
+	resultChan := make(chan fileResult, len(resultsPrefix))
 
 	resultFolderPath := utils.JoinRootPathWith("/result/" + loadTestKey)
 
 	err := utils.CreateFolderIfNotExist(utils.JoinRootPathWith("/result"))
 	if err != nil {
-		return err
+		return outcome, err
 	}
 
 	err = utils.CreateFolderIfNotExist(resultFolderPath)
 	if err != nil {
-		return err
+		return outcome, err
 	}
 
 	maxRetries := config.AppConfig.Load.Retry
@@ -147,7 +173,7 @@ func rsyncFiles(f *fetchDataParam) error {
 			err := utils.InlineCmd(cmd)
 
 			if err == nil {
-				errorChan <- nil
+				resultChan <- fileResult{prefix: prefix}
 				return // Success, exit the retry loop
 			}
 
@@ -160,7 +186,7 @@ func rsyncFiles(f *fetchDataParam) error {
 			}
 		}
 
-		errorChan <- fmt.Errorf("failed to rsync %s after %d attempts", fileName, maxRetries)
+		resultChan <- fileResult{prefix: prefix, err: fmt.Errorf("failed to rsync %s after %d attempts", fileName, maxRetries)}
 	}
 
 	if installLocation == constant.Local || installLocation == constant.Remote {
@@ -171,14 +197,20 @@ func rsyncFiles(f *fetchDataParam) error {
 	}
 
 	wg.Wait()
-	close(errorChan)
+	close(resultChan)
 
-	// Collect errors from the error channel
-	for err := range errorChan {
-		if err != nil {
-			return err
+	var mainErr error
+	for r := range resultChan {
+		if r.err == nil {
+			continue
 		}
+		if r.prefix == "" {
+			mainErr = r.err // the load figures themselves
+			continue
+		}
+		outcome.MissingMetrics = append(outcome.MissingMetrics, strings.TrimPrefix(r.prefix, "_"))
 	}
+	sort.Strings(outcome.MissingMetrics)
 
-	return nil
+	return outcome, mainErr
 }

--- a/internal/core/load/rsync_fetch_service.go
+++ b/internal/core/load/rsync_fetch_service.go
@@ -70,24 +70,24 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 			// rsync failure is visible (previously it was only logged and the run was still
 			// marked successed).
 			f.StepRec.begin(constant.StepResultFetch, "Collecting results")
-			retry := config.AppConfig.Load.Retry
-			var fetchErr error
-			var outcome fetchOutcome
-			for retry > 0 {
-				if !f.isRunning() {
-					outcome, fetchErr = rsyncFiles(f)
-					if fetchErr != nil {
-						log.Error().Msgf("error while fetching data from rsync %s", fetchErr.Error())
-					}
-					break
-				}
-				time.Sleep(time.Duration(1<<4-retry) * time.Second)
-				retry--
-			}
+
+			// Wait for the metric files rather than taking one look and moving on.
+			//
+			// Every chart on the results screen is drawn from these csv files, and they are
+			// written while the run is still going, so the metric ones routinely land after
+			// the main result. There is no way to ask for them again afterwards, so a run
+			// that gives up here loses its charts for good.
+			//
+			// Waiting stops when the set of missing files stops shrinking: files still
+			// arriving means more are coming, while nothing new across a whole round means
+			// nothing more is coming.
+			outcome, fetchErr := l.collectResults(f)
 
 			switch {
 			case fetchErr != nil:
-				f.StepRec.fail(constant.StepResultFetch, "Result collection failed", fmt.Sprintf("the load test finished but collecting the result files (rsync) failed: %v", fetchErr))
+				f.StepRec.fail(constant.StepResultFetch, "Result collection failed",
+					fmt.Sprintf("the load test finished but the main result file could not be collected from the generator (%s): %v",
+						f.PublicIp, fetchErr))
 			case len(outcome.MissingMetrics) > 0:
 				// The run stands on its own load figures. Say which charts will be empty and
 				// why, so an empty chart is not read as "the load produced nothing".
@@ -101,6 +101,52 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 		}
 	}
 }
+
+// collectResults keeps fetching until the files stop arriving.
+//
+// It returns as soon as everything is in. Otherwise it keeps going while progress is being
+// made - each round that brings a new file earns another round - and stops once a whole round
+// adds nothing, or when the overall deadline passes.
+func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
+	deadline := time.Now().Add(resultCollectWindow)
+	var outcome fetchOutcome
+	var err error
+	previousMissing := -1
+
+	for round := 1; ; round++ {
+		if f.isRunning() {
+			time.Sleep(resultCollectInterval)
+			continue
+		}
+
+		outcome, err = rsyncFiles(f)
+		if err != nil {
+			log.Error().Msgf("error while fetching data from rsync %s", err.Error())
+			return outcome, err
+		}
+		if len(outcome.MissingMetrics) == 0 {
+			return outcome, nil
+		}
+
+		madeProgress := previousMissing < 0 || len(outcome.MissingMetrics) < previousMissing
+		previousMissing = len(outcome.MissingMetrics)
+
+		if !madeProgress || time.Now().After(deadline) {
+			log.Warn().Msgf("giving up on metric files after %d rounds: %v", round, outcome.MissingMetrics)
+			return outcome, nil
+		}
+
+		f.StepRec.progress(constant.StepResultFetch, round,
+			fmt.Sprintf("Collecting results - still waiting for %s", strings.Join(outcome.MissingMetrics, ", ")),
+			"metric files are written during the run and can arrive after the main result")
+		time.Sleep(resultCollectInterval)
+	}
+}
+
+const (
+	resultCollectInterval = 10 * time.Second
+	resultCollectWindow   = 10 * time.Minute
+)
 
 // fetchOutcome says which result files made it across. The distinction matters: the load
 // figures come from the main file, while the cpu/disk/memory/network files are metrics

--- a/internal/core/load/step_tree.go
+++ b/internal/core/load/step_tree.go
@@ -92,8 +92,12 @@ func rollUp(p *LoadTestExecutionStepResult, now time.Time) {
 	}
 
 	p.StartAt = start
-	// A phase is only finished once nothing under it is still going.
-	if allDone {
+	// A phase is finished once nothing under it is still going — or once the phase itself has
+	// stopped, which is what happens when a step fails: the ones after it stay pending because
+	// they were never reached, not because they are still to come. Reading allDone alone let a
+	// failed phase go on counting, so a precheck that gave up after four seconds was still
+	// reporting seven minutes when the console next polled.
+	if allDone || p.Status.Terminal() {
 		p.FinishAt = finish
 	} else {
 		p.FinishAt = nil

--- a/internal/core/load/step_tree.go
+++ b/internal/core/load/step_tree.go
@@ -1,0 +1,118 @@
+package load
+
+import (
+	"sort"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+)
+
+// buildStepTree turns the flat step rows into the phase/sub-step shape the console renders,
+// and stamps every node with how long it has taken (BAR-1553).
+//
+// The flat list could not explain where a run's time went: a run stuck for 27 minutes unable
+// to reach the metric agent and a run busy generating load both showed "jmeter_run: running".
+// Sub-steps split that span, and the elapsed figure tells a slow step from a stuck one.
+//
+// A phase's own timing is derived from its children rather than recorded separately, so the
+// two can never disagree.
+func buildStepTree(steps []LoadTestExecutionStep, now time.Time) []LoadTestExecutionStepResult {
+	phases := make(map[constant.ExecutionStep]*LoadTestExecutionStepResult)
+	var order []constant.ExecutionStep
+
+	phaseOf := func(name constant.ExecutionStep) *LoadTestExecutionStepResult {
+		if p, ok := phases[name]; ok {
+			return p
+		}
+		p := &LoadTestExecutionStepResult{Name: name, Status: constant.StepPending}
+		phases[name] = p
+		order = append(order, name)
+		return p
+	}
+
+	for _, s := range steps {
+		node := LoadTestExecutionStepResult{
+			Seq:        s.Seq,
+			Name:       s.Name,
+			Status:     s.Status,
+			Attempt:    s.Attempt,
+			StartAt:    s.StartAt,
+			FinishAt:   s.FinishAt,
+			Message:    s.Message,
+			Detail:     s.Detail,
+			ElapsedSec: elapsedSec(s.StartAt, s.FinishAt, now),
+		}
+
+		if parent := s.Name.Parent(); parent != "" {
+			p := phaseOf(parent)
+			p.Children = append(p.Children, node)
+			continue
+		}
+
+		p := phaseOf(s.Name)
+		// Keep the children already collected; the row itself supplies the rest.
+		children := p.Children
+		*p = node
+		p.Children = children
+	}
+
+	out := make([]LoadTestExecutionStepResult, 0, len(order))
+	for _, name := range order {
+		p := phases[name]
+		sort.SliceStable(p.Children, func(i, j int) bool { return p.Children[i].Seq < p.Children[j].Seq })
+		rollUp(p, now)
+		out = append(out, *p)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Seq < out[j].Seq })
+	return out
+}
+
+// rollUp gives a phase the span of its children. Without this a phase would report the moment
+// its own row was written, which says nothing about how long the work underneath took.
+func rollUp(p *LoadTestExecutionStepResult, now time.Time) {
+	if len(p.Children) == 0 {
+		return
+	}
+
+	start := p.StartAt
+	var finish *time.Time
+	allDone := true
+
+	for i := range p.Children {
+		c := p.Children[i]
+		if c.StartAt != nil && (start == nil || c.StartAt.Before(*start)) {
+			start = c.StartAt
+		}
+		if c.FinishAt != nil && (finish == nil || c.FinishAt.After(*finish)) {
+			finish = c.FinishAt
+		}
+		if c.Status == constant.StepPending || c.Status == constant.StepRunning {
+			allDone = false
+		}
+	}
+
+	p.StartAt = start
+	// A phase is only finished once nothing under it is still going.
+	if allDone {
+		p.FinishAt = finish
+	} else {
+		p.FinishAt = nil
+	}
+	p.ElapsedSec = elapsedSec(p.StartAt, p.FinishAt, now)
+}
+
+// elapsedSec reports the whole span for a finished step, and the time so far for one still
+// running. A step that has not started yet reports nothing.
+func elapsedSec(start, finish *time.Time, now time.Time) int {
+	if start == nil {
+		return 0
+	}
+	end := now
+	if finish != nil {
+		end = *finish
+	}
+	if end.Before(*start) {
+		return 0
+	}
+	return int(end.Sub(*start).Seconds())
+}

--- a/internal/core/load/step_tree_test.go
+++ b/internal/core/load/step_tree_test.go
@@ -97,6 +97,29 @@ func TestPhasesAreOrdered(t *testing.T) {
 	}
 }
 
+// A failed phase stops when it fails. The steps after it stay pending because they were never
+// reached — reading that as "still going" made a precheck that gave up in four seconds report
+// seven minutes and climbing.
+func TestFailedPhaseStopsCounting(t *testing.T) {
+	base := time.Date(2026, 7, 19, 15, 0, 49, 0, time.UTC)
+	now := base.Add(7 * time.Minute)
+
+	tree := buildStepTree([]LoadTestExecutionStep{
+		{Seq: 1, Name: constant.StepPrecheck, Status: constant.StepFailed},
+		{Seq: 1, Name: constant.SubTargetExists, Status: constant.StepOk, StartAt: at(base, 0), FinishAt: at(base, 0)},
+		{Seq: 4, Name: constant.SubMetricPortOpen, Status: constant.StepFailed, StartAt: at(base, 0), FinishAt: at(base, 4)},
+		{Seq: 5, Name: constant.SubRemoteCommand, Status: constant.StepPending},
+	}, now)
+
+	phase := tree[0]
+	if phase.FinishAt == nil || !phase.FinishAt.Equal(base.Add(4*time.Second)) {
+		t.Fatalf("a failed phase finishes with its last attempted sub-step, got %v", phase.FinishAt)
+	}
+	if phase.ElapsedSec != 4 {
+		t.Errorf("expected 4s, got %d", phase.ElapsedSec)
+	}
+}
+
 func TestParent(t *testing.T) {
 	if got := constant.SubAgentPort.Parent(); got != constant.StepAgentInstall {
 		t.Errorf("expected %s, got %s", constant.StepAgentInstall, got)

--- a/internal/core/load/step_tree_test.go
+++ b/internal/core/load/step_tree_test.go
@@ -1,0 +1,114 @@
+package load
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cloud-barista/cm-ant/internal/core/common/constant"
+)
+
+func at(base time.Time, sec int) *time.Time {
+	t := base.Add(time.Duration(sec) * time.Second)
+	return &t
+}
+
+// A phase must report the span of the work underneath it. Recording the phase's own timing
+// separately is what let a 27 minute wait hide behind a step that claimed to be running load.
+func TestPhaseSpansItsChildren(t *testing.T) {
+	base := time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC)
+	now := base.Add(100 * time.Second)
+
+	tree := buildStepTree([]LoadTestExecutionStep{
+		{Seq: 3, Name: constant.StepAgentInstall, Status: constant.StepRunning},
+		{Seq: 1, Name: constant.SubAgentInstall, Status: constant.StepOk, StartAt: at(base, 0), FinishAt: at(base, 10)},
+		{Seq: 2, Name: constant.SubAgentProcess, Status: constant.StepOk, StartAt: at(base, 10), FinishAt: at(base, 12)},
+		{Seq: 3, Name: constant.SubAgentPort, Status: constant.StepRunning, StartAt: at(base, 12)},
+	}, now)
+
+	if len(tree) != 1 {
+		t.Fatalf("expected one phase, got %d", len(tree))
+	}
+	phase := tree[0]
+	if len(phase.Children) != 3 {
+		t.Fatalf("expected three sub-steps, got %d", len(phase.Children))
+	}
+	if phase.StartAt == nil || !phase.StartAt.Equal(base) {
+		t.Errorf("phase should start when its first sub-step did, got %v", phase.StartAt)
+	}
+	if phase.FinishAt != nil {
+		t.Errorf("phase is not finished while a sub-step still runs, got %v", phase.FinishAt)
+	}
+	if phase.ElapsedSec != 100 {
+		t.Errorf("running phase should report time so far (100s), got %d", phase.ElapsedSec)
+	}
+	if got := phase.Children[2].ElapsedSec; got != 88 {
+		t.Errorf("running sub-step should report time so far (88s), got %d", got)
+	}
+}
+
+func TestFinishedPhaseReportsWholeSpan(t *testing.T) {
+	base := time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC)
+	now := base.Add(time.Hour) // long after the fact — must not affect a finished step
+
+	tree := buildStepTree([]LoadTestExecutionStep{
+		{Seq: 1, Name: constant.StepPrecheck, Status: constant.StepOk},
+		{Seq: 1, Name: constant.SubTargetExists, Status: constant.StepOk, StartAt: at(base, 0), FinishAt: at(base, 1)},
+		{Seq: 2, Name: constant.SubTargetReachable, Status: constant.StepOk, StartAt: at(base, 1), FinishAt: at(base, 4)},
+	}, now)
+
+	phase := tree[0]
+	if phase.FinishAt == nil || !phase.FinishAt.Equal(base.Add(4*time.Second)) {
+		t.Fatalf("phase should finish with its last sub-step, got %v", phase.FinishAt)
+	}
+	if phase.ElapsedSec != 4 {
+		t.Errorf("finished phase should report its own span (4s), got %d", phase.ElapsedSec)
+	}
+}
+
+// A phase with no sub-steps recorded still has to render — older rows look like this.
+func TestPhaseWithoutChildrenKeepsOwnTiming(t *testing.T) {
+	base := time.Date(2026, 7, 19, 9, 0, 0, 0, time.UTC)
+
+	tree := buildStepTree([]LoadTestExecutionStep{
+		{Seq: 4, Name: constant.StepJmeterRun, Status: constant.StepOk, StartAt: at(base, 0), FinishAt: at(base, 35)},
+	}, base.Add(time.Minute))
+
+	if len(tree) != 1 || len(tree[0].Children) != 0 {
+		t.Fatalf("expected a childless phase, got %+v", tree)
+	}
+	if tree[0].ElapsedSec != 35 {
+		t.Errorf("expected 35s, got %d", tree[0].ElapsedSec)
+	}
+}
+
+// Phases come back in the order a run goes through them, whatever order the rows arrive in.
+func TestPhasesAreOrdered(t *testing.T) {
+	tree := buildStepTree([]LoadTestExecutionStep{
+		{Seq: 5, Name: constant.StepJmeterRun, Status: constant.StepPending},
+		{Seq: 1, Name: constant.StepPrecheck, Status: constant.StepPending},
+		{Seq: 2, Name: constant.StepGeneratorInstall, Status: constant.StepPending},
+	}, time.Now())
+
+	want := []constant.ExecutionStep{constant.StepPrecheck, constant.StepGeneratorInstall, constant.StepJmeterRun}
+	for i, w := range want {
+		if tree[i].Name != w {
+			t.Errorf("position %d: expected %s, got %s", i, w, tree[i].Name)
+		}
+	}
+}
+
+func TestParent(t *testing.T) {
+	if got := constant.SubAgentPort.Parent(); got != constant.StepAgentInstall {
+		t.Errorf("expected %s, got %s", constant.StepAgentInstall, got)
+	}
+	if got := constant.StepAgentInstall.Parent(); got != "" {
+		t.Errorf("a phase has no parent, got %s", got)
+	}
+}
+
+// A step that never started reports nothing rather than a span measured from the epoch.
+func TestNotStartedReportsNothing(t *testing.T) {
+	if got := elapsedSec(nil, nil, time.Now()); got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}

--- a/script/install-server-agent.sh
+++ b/script/install-server-agent.sh
@@ -11,6 +11,29 @@ AGENT_DOWNLOAD_URL="https://github.com/undera/perfmon-agent/releases/download/$A
 TCP_PORT="${TCP_PORT:=5555}"
 AUTO_SHUTDOWN="${AUTO_SHUTDOWN:=}"
 
+# Where this script says what it is doing. cm-ant reads it while waiting for the agent, so it
+# can tell an install still fetching packages from one that has already given up - the two look
+# identical from outside, and only one of them is worth waiting for. It lives outside the agent
+# directory so a failure before that directory exists is still recorded.
+STATE_FILE="${STATE_FILE:=/var/tmp/cm-ant-agent-install.state}"
+LOG_FILE="${LOG_FILE:=/var/tmp/cm-ant-agent-install.log}"
+
+
+record() {
+    local line
+    line="$(date -u +%Y-%m-%dT%H:%M:%SZ)	$1	${2:-}"
+    echo "$line" | sudo tee "$STATE_FILE" >/dev/null
+    echo "$line" | sudo tee -a "$LOG_FILE" >/dev/null
+}
+
+
+on_failure() {
+    local code=$?
+    record failed "exit $code at line $1: $BASH_COMMAND"
+    exit $code
+}
+trap 'on_failure $LINENO' ERR
+
 
 terminate_existing_process() {
     local pid
@@ -23,6 +46,7 @@ terminate_existing_process() {
 
 
 install_dependencies() {
+    record dependencies "installing wget, unzip and a jre"
     sudo apt-get update -y
     sudo apt-get install -y wget unzip default-jre
 }
@@ -31,25 +55,36 @@ install_dependencies() {
 install_agent() {
     if [[ -z "$(ls -A "$AGENT_WORK_DIR")" ]]; then
         echo "[CM-ANT] Installing perfmon server agent"
+        record downloading "$AGENT_DOWNLOAD_URL"
         sudo wget "$AGENT_DOWNLOAD_URL" -P "$AGENT_WORK_DIR"
+        record unpacking "$AGENT_FILE_NAME"
         sudo unzip "$AGENT_WORK_DIR/$AGENT_FILE_NAME" -d "$AGENT_WORK_DIR"
         sudo rm "$AGENT_WORK_DIR/$AGENT_FILE_NAME"
         echo "[CM-ANT] Agent installed successfully"
+    else
+        record present "agent already unpacked in $AGENT_WORK_DIR"
     fi
 }
 
 
 start_agent() {
     if [[ -e "${AGENT_WORK_DIR}/startAgent.sh" ]]; then
+        record starting "tcp port $TCP_PORT"
         nohup "${AGENT_WORK_DIR}/startAgent.sh" --udp-port 0 --tcp-port "$TCP_PORT" "$AUTO_SHUTDOWN" > /dev/null 2>&1 &
         echo "Agent started successfully in the background."
+        record started "agent started in the background on port $TCP_PORT"
     else
+        # Reached when the archive unpacked into an unexpected shape. The script has nothing
+        # left to try, and saying so is what stops cm-ant from waiting out its ceiling.
+        record failed "startAgent.sh not found under $AGENT_WORK_DIR"
         echo "Failed to start the agent. startAgent.sh not found."
+        exit 1
     fi
 }
 
 
 main() {
+    record preparing "terminating anything on port $TCP_PORT"
     terminate_existing_process
     sudo mkdir -p "$AGENT_WORK_DIR"
     install_dependencies

--- a/script/install-server-agent.sh
+++ b/script/install-server-agent.sh
@@ -12,23 +12,57 @@ TCP_PORT="${TCP_PORT:=5555}"
 AUTO_SHUTDOWN="${AUTO_SHUTDOWN:=}"
 
 # Where this script says what it is doing. cm-ant reads it while waiting for the agent, so it
-# can tell an install still fetching packages from one that has already given up - the two look
-# identical from outside, and only one of them is worth waiting for. It lives outside the agent
-# directory so a failure before that directory exists is still recorded.
+# can tell an install still working from one that has already given up - the two look identical
+# from outside, and only one of them is worth waiting for. It lives outside the agent directory
+# so a failure before that directory exists is still recorded.
 STATE_FILE="${STATE_FILE:=/var/tmp/cm-ant-agent-install.state}"
 LOG_FILE="${LOG_FILE:=/var/tmp/cm-ant-agent-install.log}"
+WORK_OUT="${WORK_OUT:=/var/tmp/cm-ant-agent-install.out}"
+
+# How often the long stages report where they have got to. The detail has to keep changing
+# while real work is happening, because that is the only thing that separates a slow download
+# from a dead one - a phase name alone says the same thing in both cases.
+HEARTBEAT_INTERVAL="${HEARTBEAT_INTERVAL:=5}"
 
 
 record() {
     local line
     line="$(date -u +%Y-%m-%dT%H:%M:%SZ)	$1	${2:-}"
-    echo "$line" | sudo tee "$STATE_FILE" >/dev/null
-    echo "$line" | sudo tee -a "$LOG_FILE" >/dev/null
+    echo "$line" > "$STATE_FILE"
+    echo "$line" >> "$LOG_FILE"
+}
+
+
+# heartbeat_start runs a reporter alongside a long stage. The command it is given must print
+# something that advances with the work - apt's own output, the size of the file being
+# downloaded - so that a value which stops changing means the work has stopped, not merely that
+# the stage is long.
+HB_PID=""
+heartbeat_start() {
+    local phase="$1" progress_cmd="$2"
+    (
+        while :; do
+            sleep "$HEARTBEAT_INTERVAL"
+            record "$phase" "$(eval "$progress_cmd" 2>/dev/null | tr -d '\r' | tr '\t\n' '  ' | tail -c 160)"
+        done
+    ) &
+    HB_PID=$!
+}
+
+heartbeat_stop() {
+    if [[ -n "$HB_PID" ]]; then
+        kill "$HB_PID" 2>/dev/null || true
+        wait "$HB_PID" 2>/dev/null || true
+        HB_PID=""
+    fi
 }
 
 
 on_failure() {
     local code=$?
+    # Stop the reporter first, or it overwrites the failure with another progress line and the
+    # install looks like it is still going.
+    heartbeat_stop
     record failed "exit $code at line $1: $BASH_COMMAND"
     exit $code
 }
@@ -47,18 +81,30 @@ terminate_existing_process() {
 
 install_dependencies() {
     record dependencies "installing wget, unzip and a jre"
-    sudo apt-get update -y
-    sudo apt-get install -y wget unzip default-jre
+    : > "$WORK_OUT"
+    # apt's last line is the progress: fetching a package, unpacking, setting up. It stops
+    # moving exactly when apt does.
+    heartbeat_start dependencies "tail -n 1 '$WORK_OUT'"
+    sudo apt-get update -y >> "$WORK_OUT" 2>&1
+    sudo apt-get install -y wget unzip default-jre >> "$WORK_OUT" 2>&1
+    heartbeat_stop
 }
 
 
 install_agent() {
     if [[ -z "$(ls -A "$AGENT_WORK_DIR")" ]]; then
         echo "[CM-ANT] Installing perfmon server agent"
+
         record downloading "$AGENT_DOWNLOAD_URL"
-        sudo wget "$AGENT_DOWNLOAD_URL" -P "$AGENT_WORK_DIR"
+        # The size of the partial file is the honest measure of a download. A slow link keeps
+        # raising it; a stalled one leaves it where it is, which is what cm-ant watches for.
+        heartbeat_start downloading \
+            "echo \"\$(stat -c%s '$AGENT_WORK_DIR/$AGENT_FILE_NAME' 2>/dev/null || echo 0) bytes of $AGENT_FILE_NAME\""
+        sudo wget "$AGENT_DOWNLOAD_URL" -P "$AGENT_WORK_DIR" >> "$WORK_OUT" 2>&1
+        heartbeat_stop
+
         record unpacking "$AGENT_FILE_NAME"
-        sudo unzip "$AGENT_WORK_DIR/$AGENT_FILE_NAME" -d "$AGENT_WORK_DIR"
+        sudo unzip "$AGENT_WORK_DIR/$AGENT_FILE_NAME" -d "$AGENT_WORK_DIR" >> "$WORK_OUT" 2>&1
         sudo rm "$AGENT_WORK_DIR/$AGENT_FILE_NAME"
         echo "[CM-ANT] Agent installed successfully"
     else


### PR DESCRIPTION
## 배경

35초짜리 부하테스트가 27분 40초 걸리는 일이 반복됐는데, 화면에서는 `jmeter_run: running` 하나로만 보여 어디에 시간이 갔는지 알 수 없었습니다. 실제로는 부하가 늦게 시작된 것이었고 — 대상의 메트릭 포트에 닿지 못해 수집기가 매초 재시도하는 동안 부하가 시작조차 못 한 상태였습니다.

같은 성격의 문제가 반복되는 이유는 두 가지였습니다. 단계가 너무 굵어 *어느 구간이 오래 걸리는지* 알 수 없었고, 환경 문제를 *모든 준비가 끝난 뒤에야* 발견했습니다.

## 무엇이 바뀌나

**단계를 계층으로 나누고 각 단계의 소요 시간을 남깁니다.** 6개 단계(사전 점검 · 발생기 · 에이전트 · 계획 · 부하 · 수집) 아래에 실제로 기다릴 수 있는 하위 단계를 두고, 끝난 단계는 전체 구간을, 진행 중인 단계는 현재까지를 보고합니다. 평소 1초 걸리던 단계가 `45s`를 가리키면 그것이 볼 곳입니다.

**환경 점검을 맨 앞에 둡니다.** 대상이 존재하는지, 기동 중인지, 부하가 보낼 그 요청에 답하는지, 메트릭 포트가 열려 있는지, 원격 명령이 오가는지를 몇 초 안에 확인합니다. 잘못된 환경은 이제 수십 분이 아니라 즉시 드러납니다.

**메시지가 조치로 이어지도록 썼습니다.** 짧은 문구는 화면에, 상세는 호버에 둡니다. 특히 같은 증상이라도 고칠 곳이 다르면 다르게 말합니다 — 연결이 거부되면 에이전트가 안 떠 있는 것이고, 아무 응답이 없으면 방화벽입니다. 이미 열린 포트를 열라고 안내하면 엉뚱한 곳을 보게 됩니다.

**에이전트 설치를 시간이 아니라 진행 여부로 판정합니다.** 상한을 늘리면 죽은 설치를 오래 기다리고, 줄이면 살아있는 설치를 끊습니다 — 끊고 다시 해도 같은 느린 다운로드를 처음부터 반복할 뿐입니다. 설치 스크립트가 진행 상태(apt 현재 줄, 받아진 바이트)를 남기고, 그 값이 90초간 움직이지 않으면 멈춘 것으로 판단합니다. 그래서 전체 상한은 오히려 넉넉하게 뒀습니다.

**결과 수집이 한 파일 때문에 통째로 실패하지 않습니다.** 메트릭 파일은 부하 결과보다 늦게 도착하는 것이 정상이라, 새 파일이 도착하는 동안 계속 받고 한 바퀴에 아무것도 늘지 않으면 멈춥니다. 끝내 안 온 파일은 조용히 빠지지 않고 이름이 남습니다.

## 검증

원격 개발 환경에서 **각 단계를 강제로 실패시킨 11개 케이스** 전부 통과했습니다. 없는 노드, 닫힌 포트, 404 경로, 메트릭 포트 차단, 에이전트 중단, 노드 정지, 원격 접속 포트 차단, 메트릭 미수집, 발생기 접근 불가, 재부팅 후 복구, 그리고 정상 실행입니다.

검증 도중 결함 3건을 발견해 함께 고쳤습니다. 셋 다 빌드·단위 테스트를 통과한 상태였고 정상 경로만 돌렸다면 드러나지 않았을 것들입니다.

- 실패한 단계가 시계를 멈추지 않아, 4초 만에 끝난 실패가 폴링할 때마다 커져 "7분째 진행 중"으로 보였습니다. 이 PR이 고치려던 증상을 그대로 재생산하는 것이라 회귀 테스트로 고정했습니다.
- 사전 점검이 메트릭 포트에 *무언가 떠 있는지*를 보고 중단했는데, 그것을 띄우는 단계가 뒤에 있었습니다. 에이전트가 한 번 죽으면 되살릴 수 없고 새 대상에서는 실행 자체가 시작되지 않았습니다. 이제 *포트가 열렸는지*만 판정합니다.
- 컨테이너를 교체하면 기존 부하 발생기에 접근하지 못해, 부하는 정상 수행되고 결과 파일만 못 가져왔습니다. cb-tumblebug을 통해 접근을 복구합니다.

## 참고

- 공개 문서 `docs/load-test-troubleshooting.md`를 추가했습니다 — 실행 전 열려 있어야 할 포트와 각 메시지의 원인·조치.
- 사용자에게 보이는 문구는 모두 영문입니다.