### PR TITLE
feat(load): save the config before pre-check for re-run, and record result collection per file

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ system metrics are collected, port `5555`. See
 [Load test — prerequisites and what the messages mean](docs/load-test-troubleshooting.md) for
 what has to be open before a run and what each step message means when something is not.
 
+A load test runs asynchronously; to read where a run is — the `executionStatus` and the
+per-step progress tree a client renders as a progress screen — see
+[Load test — reading a run's status and steps](docs/load-test-status-api.md).
+
 ### OS Image Search Configuration
 CM-ANT uses CB-Tumblebug's smart image search API to dynamically find appropriate OS images for load testing VM instances. The system supports two modes for image selection:
 
@@ -195,7 +199,8 @@ To correctly use the  price and cost features provided by CM-ANT, the following 
 
 ## How to Use 🔍
 #### 👉 [CM-ANT Swagger API Doc](https://cloud-barista.github.io/api/?url=https://raw.githubusercontent.com/cloud-barista/cm-ant/main/api/swagger.yaml)
-#### 👉 [Simple and Sample guide](https://github.com/cloud-barista/cm-ant/wiki/CM%E2%80%90ANT-Simple--&-Sample-API-Usage-guide)
+#### 👉 [Simple & Sample API Usage Guide](docs/api-usage-guide.md)
+#### 👉 [Load test — reading a run's status and steps](docs/load-test-status-api.md)
 
 
 

--- a/docs/api-usage-guide.md
+++ b/docs/api-usage-guide.md
@@ -1,0 +1,743 @@
+# Simple & Sample API Usage Guide
+
+> 이 문서는 프로젝트 GitHub wiki에서 저장소 `docs/`로 이관되었습니다. 앞으로 문서는 wiki가 아닌 저장소 `docs/`에서만 관리합니다.
+
+## 비용 추정 api 호출 흐름
+
+1. 추천 모델 조회
+2. 비용 추정 데이터 업데이트 혹은 조회
+3. 마이그레이션 프로세스
+4. 추정 사용 비용 데이터 업데이트
+5. 추정 사용 비용 데이터 조회
+
+---
+
+## 비용 추정 api 명세
+
+### 1. 비용 추정 데이터 업데이트 혹은 조회 API
+
+> ⚠️ 현행화 필요: tb 0.12.9 / cb-spider 현행화로 입·출력 구조가 변경됨 — 아래 예제는 이전 버전 기준이며 별도 현행화 예정.
+
+#### 엔드포인트
+
+`POST /api/v1/cost/estimate`
+
+#### 설명
+
+providerName, regionName, instanceType, image(optional) 정보에 대한 비용 추정 데이터를 제공합니다. 만일 Ant 의 데이터베이스에 존재하지 않는 스펙이거나 존재하지만 7 일 이내의 데이터가 아닌 경우 서브 시스템 호출을 통해 비용 정보를 가져와 저장 후 응답을 제공합니다.
+
+#### 요청 본문
+
+```json
+{
+  "specsWithFormat": [
+    {
+      "commonImage": "aws+ap-northeast-2+ubuntu22.04",
+      "commonSpec": "aws+ap-northeast-2+c4.2xlarge"
+    },
+    {
+      "commonImage": "aws+ap-northeast-2+ubuntu22.04",
+      "commonSpec": "aws+ap-northeast-2+t3.large"
+    }
+  ],
+  "specs": [
+    {
+      "providerName":"aws",
+      "regionName": "eu-south-1",
+      "instanceType":"t3a.medium",
+      "image": "ubuntu22.04"
+    }
+  ]
+}
+```
+
+- specsWithFormat 과 specs 는 둘중 하나만 넘어와도 괜찮습니다. 
+- 모든 요청의 스펙은 취합되어 결과를 제공합니다. 위의 예시 요청의 경우 총 3개의 응답 결과를 반환합니다.
+- os, lisence 에 따라 제공되는 가격이 다를 수 있습니다.
+
+`specsWithFormat`
+
+- `commonSpec (required):` `+` 구분자로 연결된 `providerName+region+instanceType` 정보입니다.
+
+- `commonImage (Optional)`: `+` 구분자로 연결된 `providerName+region+machineImage` 정보입니다.
+
+`specs`
+
+- `providerName (required):` 요청 프로바이더명 (aws | azure | alibaba | tencent | gcp | ibm)
+
+- `regionName (required)`: CSP 와 매칭되는 region 명
+
+- `instanceType (required)`: CSP 와 매칭되는 instance type
+
+- `image(optional)`: CSP 에 사용되는 os 이미지 정보입니다.
+
+---
+
+### 2. 추정 사용 비용 데이터 업데이트 API
+
+> ⚠️ 현행화 필요: tb 0.12.9 / cb-spider 현행화로 입·출력 구조가 변경됨 — 아래 예제는 이전 버전 기준이며 별도 현행화 예정.
+
+#### 엔드포인트
+
+`POST /api/v1/cost/estimate/forecast`
+
+#### 
+
+#### 설명
+
+마이그레이션 된 워크로드에 대한 운영 비용 데이터를 ant 로 불러와 저장합니다.
+저장 가능한 기간은 현재 부터 **최대 14일간의 비용데이터만 저장 가능하며, 호출 1건당 Cost Explorer Api 사용 비용 0.01$ 가 연결된 aws 계정에 청구**됩니다.
+
+Tumblebug 에서 사용하는 nsId 와 mcsId 에 해당하는 리소스 (현재는 instance id 만 취득 가능) 의 정보를 가지고 와 해당하는 가격 정보를 업데이트합니다.
+
+현재 제공되는 provider 는 aws 이며 추후 확장 예정입니다.
+
+#### 요청 파라미터
+
+```json
+{
+    "nsId": "ns01",
+    "mciId": "mci01"
+} 
+```
+
+---
+
+### 3. 추정 사용 비용 데이터 조회 API
+
+> ⚠️ 현행화 필요: tb 0.12.9 / cb-spider 현행화로 입·출력 구조가 변경됨 — 아래 예제는 이전 버전 기준이며 별도 현행화 예정.
+
+#### 엔드포인트
+
+`GET /api/v1/cost/estimate/forecast`
+
+#### 설명
+
+사용자의 필터 조건에 맞는 추정 사용 비용 데이터를 ant 의 데이터베이스에서 조회합니다. 추정 사용 비용  데이터 업데이트를 진행한 후 조회를 진행해야 합니다.
+ ant 의 데이터베이스에서 조회하기 때문에 별도의 api 호출 비용이 발생하지 않습니다.
+
+```text
+Query Param: startDate(format 2024-09-10), endDate(format 2024-09-15), costAggregationType, providerName, nsIds, mciIds, resourceTypes, resourceIds, dateOrder, resourceTypeOrder
+```
+
+#### 
+
+#### 요청 파라미터
+
+- startDate: 2024-10-08 형식의 시작 날짜(포함)
+- endDate: 2024-10-08 형식의 종료 날짜(포함)
+- costAggregationType: 비용 데이터 조회 묶음 간격 (*daily|weekly|monthly)
+- providerName: provider 로 필터링 하기 위한 값 (현재는 aws 만 제공)
+- nsIds: 조회 원하는 nsId 목록
+- mciIds: 조회 원하는 mciId 목록
+- resourceType: 조회를 원하는 리소스 타입 (VM|VNet|DataDisk|Etc|)
+- resourceIds: 조회 원하는 리소스 id 목록
+- dateOrder: 날짜 기준 오름차순 내림차순 (asc|desc)
+- resourceTypeOrder: resourceType 오름차순 내림차순 (asc|desc)
+
+#### 
+
+#### 응답 결과
+
+```json
+{
+        "code": 200,
+        "result": {
+            "getEstimateForecastCostInfoResults": [
+                {
+                    "category": "Amazon Elastic Compute Cloud - Compute",
+                    "date": "2024-11-08T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.6912,
+                    "unit": "USD"
+                },
+                {
+                    "category": "EC2 - Other",
+                    "date": "2024-11-08T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.0002170775,
+                    "unit": "USD"
+                },
+                {
+                    "category": "Amazon Elastic Compute Cloud - Compute",
+                    "date": "2024-11-09T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.6912,
+                    "unit": "USD"
+                },
+                {
+                    "category": "EC2 - Other",
+                    "date": "2024-11-09T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.0000351517,
+                    "unit": "USD"
+                },
+                {
+                    "category": "Amazon Elastic Compute Cloud - Compute",
+                    "date": "2024-11-10T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.6912,
+                    "unit": "USD"
+                },
+                {
+                    "category": "EC2 - Other",
+                    "date": "2024-11-10T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.0000353784,
+                    "unit": "USD"
+                },
+                {
+                    "category": "Amazon Elastic Compute Cloud - Compute",
+                    "date": "2024-11-11T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-0e6a610a7111e574e",
+                    "resourceType": "VM",
+                    "totalCost": 0.6912,
+                    "unit": "USD"
+                },
+                {
+                    "category": "EC2 - Other",
+                    "date": "2024-11-11T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-xxxxxxx",
+                    "resourceType": "VM",
+                    "totalCost": 0.0000362429,
+                    "unit": "USD"
+                },
+                {
+                    "category": "Amazon Elastic Compute Cloud - Compute",
+                    "date": "2024-11-12T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-xxxxxxx",
+                    "resourceType": "VM",
+                    "totalCost": 0.6912,
+                    "unit": "USD"
+                },
+                {
+                    "category": "EC2 - Other",
+                    "date": "2024-11-12T00:00:00Z",
+                    "provider": "aws",
+                    "resourceId": "i-xxxxxxx",
+                    "resourceType": "VM",
+                    "totalCost": 0.0000465391,
+                    "unit": "USD"
+                }
+            ],
+            "resultCount": 27
+        },
+        "successMessage": "Successfully get estimate forecast cost"
+    }
+```
+
+---
+
+### 5. 사용 비용 추정 RAW 데이터 업데이트 API
+
+> ⚠️ 현행화 필요: tb 0.12.9 / cb-spider 현행화로 입·출력 구조가 변경됨 — 아래 예제는 이전 버전 기준이며 별도 현행화 예정.
+
+#### 설명
+
+마이그레이션 된 워크로드에 대한 운영 비용 데이터를 ant 로 불러와 저장합니다.
+저장 가능한 기간은 현재 부터 최대 14일간의 비용데이터만 저장 가능하며, 호출 1건당 Cost Explorer Api 사용 비용 0.01$ 가 연결된 aws 계정에 청구됩니다.
+
+이는 ns와 mci 와 상관없이 원하는 리소스의 id 를 통해서 비용 데이터를 ant 로 저장할 수 있습니다.
+
+```json
+{
+  "migrationId": "1",  ## 현재 사용되지 않으나 추후 마이그레이션 id 를 통해 관련 리소스에 대한 정보를 조회할 수 있을 것으로 생각하고 넣어둔 값
+  "connectionName": "aws-us-east-1",
+  "costResources": [
+    {
+      "resourceType": "VM",
+      "resourceIds": [
+        "i-02dxxxxxxdec4"
+      ]
+    },
+    {
+      "resourceType": "VNet",
+      "resourceIds": [
+          "eni-06cxxxxxx02e34"
+      ]
+    },
+    {
+      "resourceType": "DataDisk",
+      "resourceIds": [
+          "vol-0917xxxxxxe2f6"
+      ]
+    }
+  ],
+  "awsAdditionalInfo": {  # eni 추가 시 자원 별 사용 가격 데이터 조회를 위한 id 조합을 위해 필요한 데이터
+    "ownerId": "xxxxxxxxxxxx",  # 12 자리 숫자
+    "regions": [
+      "ap-northeast-2"
+    ]
+  }
+}
+```
+
+#### 요청 파라미터
+
+- migrationId (현재 사용하지 않습니다.): 현재 사용되지 않으나 추후 마이그레이션 id 를 통해 관련 리소스에 대한 정보를 조회할 수 있을 것으로 생각하고 넣어둔 값
+- connectionId : 조회를 위해 사용되는 등록된 aws connection 이름 (변경 예정)
+- costResources: 비용 정보를 조회하기 위해 필요한 내용
+  - resourceType: 어떤 리소스의 비용 정보를 조회할 것인지 정의 (VM|VNet|DataDisk)
+  - resourceIds: 해당 타입에 해당하는 리소스 id 리스트
+- awsAdditionalInfo: aws 비용 조회에 추가적으로 필요한 데이터
+  - ownerId: 12자리 숫자로 구성된 aws 값
+  - regions: eni 조합시 필요한 region 이름 (VNet 비용 조회 용도)
+
+---
+
+## 성능 평가 api 호출 흐름
+
+1. migration 된 워크로드 선택
+   - nsId, mciId, vmId
+2. metrics agent 설치 요청
+3. 성능 평가를 위한 시나리오 사용자 입력 후 성능 평가 수행
+4. 워크로드를 대상으로 수행한 성능 평가 상태 조회
+   - 워크로드에 상태 표시가 가능하도록
+5. 워크로드를 대상으로 수행한 성능 평가 결과 조회
+
+### 참고 사항
+
+현재 마이그레이션 된 워크로드와 성능 평가 실행 사이에 연결 관계가 프레임워크에 정의되어 있지 않습니다. <br>
+성능 평가 흐름상 워크로드와 성능 평가는 링크가 필요해 보이며 지난번 말씀주셨던 것 처럼 연결 고리를 추가 예정입니다.
+
+---
+
+## 성능 평가 api 명세
+
+### 1. 성능평가 지표 수집 에이전트 설치 (optional)
+
+#### 엔드포인트
+
+`POST /api/v1/load/monitoring/agent/install`
+
+#### 설명
+
+성능 평가시 추가적으로 지표 정보를 수집하기 위해 사용할 메트릭 에이전트를 설치하는 단계입니다. 메트릭 에이전트를 통해 부하 발생 시 인프라의 CPU, 메모리, 네트워크 I/O, 디스크 I/O 등의 지표 정보를 수집합니다.
+
+별도로 설치하지 않고 성능 평가를 진행하는 경우 latency 와 request per second 등 http 요청에 대한 지표만 수집합니다.
+
+성능 평가를 수행하면 agent 로 metrics 를 수집하는 옵션을 선택할 수 있습니다.
+
+```json
+{
+  "nsId": "nsId",
+  "mcisId": "mcisId",
+  "vmId": "vmId"  # optional 
+}
+```
+
+#### 요청 프로퍼티
+
+- nsId: 네임스페이스 ID
+- mciId: MCI ID
+- vmId: VM ID
+
+-----
+
+### 2. 성능 평가용 Load Generator 설치 (optional)
+
+#### 엔드포인트
+
+`POST /api/v1/load/generators`
+
+#### 설명
+
+성능 평가 실행을 위해 부하를 발생하기 위한 Load Generator를 설치하는 단계입니다. 
+Local 또는 Remote 환경에 설치할 수 있습니다.
+
+별도로 설치하지 않고 성능 평가를 실행하는 경우 부하 발생 실행 요청의 프로퍼티인 `installLocation` 을 확인하여 부하 발생기 설치를 진행합니다.
+
+```json
+{
+  "installLocation": "local"  // local | remote
+}
+```
+
+#### 프로퍼티
+
+- installLocation: 설치 위치 (local 또는 remote)
+  
+  - local: 현재 ANT가 작동하는 환경(Ubuntu 기반)에 설치
+  
+  - remote: Tumblebug의 recommendVM을 통해 VM을 프로비저닝한 후 프로비저닝 된 VM 에 설치
+    
+    | t2.medium | 2   | 4.0 |
+    | --------- | --- | --- |
+
+-----
+
+### 3. 성능 평가를 위한 부하 발생 시작
+
+#### 엔드포인트
+
+`POST /api/v1/load/tests/run`
+
+#### 설명
+
+성능 평가를 위한 부하 테스트를 실행하는 단계입니다.
+
+앞선 단계인 성능평가 지표 수집 에이전트 설치 및 성능 평가 부하 발생기 설치하는 과정을 포함하고 있는 API 입니다.
+
+```json
+{
+        "agentHostname": "",
+        "collectAdditionalSystemMetrics": true,
+        "httpReqs": [
+            {
+                "bodyData": "",
+                "hostname": "xx.xxx.xx.xxx",
+                "method": "get",
+                "path": "",
+                "port": "80",
+                "protocol": "http"
+            }
+        ],
+        "installLoadGenerator": {
+            "installLocation": "remote"
+        },
+        "nsId": "mig01",
+        "mciId": "mmci01",
+        "vmId": "vm01-1",
+        "testName": "first test gogo",
+        "virtualUsers": "10",
+        "duration": "20",
+        "rampUpTime": "20",
+        "rampUpSteps": "3"
+    }
+```
+
+부하 발생 실행 요청은 즉시 반환되며, 응답으로 `loadTestKey` 를 받습니다. 실제 부하 테스트(사전 점검 → 부하 발생기 설치 → 부하 발생 → 결과 수집)는 비동기로 진행되므로, 진행 상태는 아래 **4. 부하 발생 상태 확인** 을 통해 조회합니다.
+
+#### 프로퍼티
+
+- installLoadGenerator: Load Generator 설치 위치 (앞서 설치한 경우 설치 스킵)
+  - installLocation: 설치 위치 (remote 또는 local)
+- testName: 테스트 이름
+- virtualUsers: 가상 사용자 수
+- duration: 테스트 실행 시간 (초 단위)
+- rampUpTime: 부하 증가 시간 (초 단위)
+- rampUpSteps: 부하 증가 단계 수
+- hostname: 테스트 대상 호스트명
+- port: 포트 번호
+- agentHostname: 에이전트가 설치된 호스트명 (Optional)
+- collectAdditionalSystemMetrics: 에이전트를 통해 메트릭 수집 여부 확인
+- httpReqs: HTTP 요청 리스트
+  - method: HTTP 메소드 (GET, POST)
+  - protocol: 통신 프로토콜 (http, https)
+  - hostname: 요청할 호스트명
+  - port: 포트 번호
+  - path: 요청 경로
+  - bodyData: 요청 본문 데이터 (Optional)
+
+-----
+
+### 4. 부하 발생 상태 확인
+
+#### 엔드포인트
+
+부하 발생 상태는 두 가지 방법으로 조회할 수 있습니다.
+
+- `GET /api/v1/load/tests/state/{loadTestKey}` — 특정 테스트 키의 실행 상태 조회
+- `GET /api/v1/load/tests/state/last` (operationId `GetLastLoadTestExecutionState`) — 특정 워크로드(node)에 대해 **마지막으로 수행된** 실행 상태 조회. node 는 쿼리 파라미터 `nsId` / `mciId` / `vmId` 로 지정합니다.
+
+> node id 는 이름이라 재사용될 수 있으므로, "이 워크로드의 마지막 실행"을 계속 보여주는 화면은 응답의 `nodeUid` 로 그 실행이 이후 교체된 VM의 것인지 구분해야 합니다.
+
+#### 설명
+
+부하 발생 상태를 확인합니다. 부하 발생이 진행되고 있는 상태와 정보를 반환합니다.
+
+```text
+Path Param
+loadTestKey: 성능 평가 실행 시 반환된 테스트 키
+```
+
+응답에는 실행의 진행을 세부적으로 표현하기 위한 필드가 포함됩니다.
+
+- `executionStatus`: 실행 전체 상태. 값은 `on_processing`(사전 점검·설치·부하 발생 등 진행 중) · `on_fetching`(부하는 끝났고 결과 수집 중) · `successed`(완료, 결과 조회 가능) · `test_failed`(완료 전 중단, 원인은 `failureMessage`)
+- `startAt` / `finishAt`: 실행 시작·종료 시각 (진행 중이면 `finishAt` 은 null)
+- `expectedFinishAt`, `totalExpectedExecutionSecond`: duration + ramp-up 으로 계산한 예상 종료. 부하 이전의 점검·설치는 포함하지 않으므로 진행 바의 힌트로만 사용합니다.
+- `failureMessage`: 실패 시 한 줄 사유 (성공 시 비어 있음)
+- `nodeUid`: 대상 node 의 uid. node id 는 재사용되므로 실행이 어느 VM에 속하는지 식별하는 데 사용합니다.
+- `steps`: 실행의 단계별 진행을 **트리**로 표현합니다. 최상위는 실행이 거치는 *phase* 이고, 각 phase 의 하위 단계는 `children` 에 담깁니다. phase 만 필요한 경우 `children` 을 무시하고 phase 행만 읽으면 됩니다.
+
+`steps[]` 각 노드(phase 또는 sub-step)의 필드:
+
+- `seq`: 실행 내 순서
+- `name`: 단계 식별자. phase 는 단일 이름(`precheck`), sub-step 은 `phase.sub` 형태(`precheck.target_reachable`)
+- `status`: `pending` · `running` · `ok` · `failed` · `skipped`
+- `message`: 현재 상태를 나타내는 짧은 한 줄 (지금 무엇을 하는지 표시할 때 사용)
+- `detail`: 실패 시 보여줄 상세 진단·오류 원인 (여러 줄일 수 있음)
+- `elapsedSec`: 해당 단계 소요 시간. 완료된 단계는 전체 구간, 진행 중이면 지금까지의 시간. phase 값은 children 에서 합산됩니다.
+- `children`: phase 의 하위 단계 목록
+
+#### 응답 예시
+
+```json
+{
+        "code": 200,
+        "result": {
+            "compileDuration": "436.008µs",
+            "createdAt": "2024-11-05T06:22:08.832848Z",
+            "executionDuration": "1m4.032562237s",
+            "executionStatus": "on_processing",
+            "id": 1,
+            "loadGeneratorInstallInfo": {
+                "createdAt": "2024-11-05T06:19:27.85666Z",
+                "id": 1,
+                "installLocation": "local",
+                "installPath": "/opt/ant/jmeter",
+                "installType": "jmeter",
+                "installVersion": "5.6",
+                "status": "installed",
+                "updatedAt": "2024-11-05T06:22:08.824086Z"
+            },
+            "loadTestKey": "1730787567844-loadtest-key-example",
+            "nodeUid": "vm-9f2c1a7b-3e40-4d21-9c88-0a1b2c3d4e5f",
+            "startAt": "2024-11-05T06:22:08.828219Z",
+            "finishAt": null,
+            "expectedFinishAt": "2024-11-05T06:23:08.828219Z",
+            "totalExpectedExecutionSecond": 60,
+            "failureMessage": "",
+            "updatedAt": "2024-11-05T06:23:12.869756Z",
+            "steps": [
+                {
+                    "seq": 1,
+                    "name": "precheck",
+                    "status": "ok",
+                    "message": "Checking the environment",
+                    "elapsedSec": 5,
+                    "children": [
+                        {
+                            "seq": 1,
+                            "name": "precheck.target_exists",
+                            "status": "ok",
+                            "elapsedSec": 1
+                        },
+                        {
+                            "seq": 3,
+                            "name": "precheck.target_reachable",
+                            "status": "ok",
+                            "message": "Target port 80 reachable",
+                            "elapsedSec": 3
+                        },
+                        {
+                            "seq": 4,
+                            "name": "precheck.metric_port_open",
+                            "status": "skipped",
+                            "message": "Metrics not requested"
+                        }
+                    ]
+                },
+                {
+                    "seq": 2,
+                    "name": "generator_install",
+                    "status": "ok",
+                    "elapsedSec": 12
+                },
+                {
+                    "seq": 3,
+                    "name": "agent_install",
+                    "status": "skipped",
+                    "message": "Metrics not requested"
+                },
+                {
+                    "seq": 4,
+                    "name": "jmx_prepare",
+                    "status": "ok",
+                    "elapsedSec": 1
+                },
+                {
+                    "seq": 5,
+                    "name": "jmeter_run",
+                    "status": "running",
+                    "message": "Generating load",
+                    "elapsedSec": 22
+                },
+                {
+                    "seq": 6,
+                    "name": "result_fetch",
+                    "status": "pending",
+                    "children": [
+                        {
+                            "seq": 1,
+                            "name": "result_fetch.file_result",
+                            "status": "pending"
+                        },
+                        {
+                            "seq": 2,
+                            "name": "result_fetch.file_cpu",
+                            "status": "pending"
+                        }
+                    ]
+                }
+            ]
+        },
+        "successMessage": "Successfully retrieved load test execution state information"
+    }
+```
+
+> `steps` 트리(phase ↔ sub-step)의 전체 구조·각 phase 의 하위 단계·`result_fetch` 결과 파일 수집 방식 등 상세는 [docs/load-test-status-api.md](load-test-status-api.md) 를 참고하세요. 실패 시 각 단계 메시지의 의미는 [docs/load-test-troubleshooting.md](load-test-troubleshooting.md) 를 참고하세요.
+
+------
+
+### 5. 성능 평가 결과 확인
+
+#### 엔드포인트
+
+`GET /api/v1/load/tests/result`
+
+`GET /api/v1/load/tests/result/metrics`
+
+#### 설명
+
+부하 발생이 완료된 후, 성능 평가 결과를 조회하는 단계입니다.
+
+```text
+Query Param
+
+loadTestKey: 성능 평가 실행 시 반환된 테스트 키
+format: 결과 형식 (normal | aggregate)
+```
+
+만약 모니터링 에이전트가 설치된 경우, 메트릭 에이전트를 통해 수집된 cpu, memory, disk, network 등 데이터를 metrics 결과 조회 API 호출을 통해 확인해볼 수 있습니다.
+
+```text
+Query Param:
+loadTestKey: 성능 평가 실행 시 반환된 테스트 키
+```
+
+#### 성능 평가 결과 조회 응답
+
+aggregate 의 경우 결과에 대한 집계된 값입니다. 데이터 샘플링 없이 모든 데이터에 대한 집계된 값을 제공합니다.
+
+
+normal 은 시계열 데이터로 표현되는 응답값입니다. 결과데이터는 100ms 단위로 평균값을 계산하여 가장 근접한 값을 찾아내 샘플링한 결과값을 추출하여 제공합니다.
+
+```json
+ "[aggregate]": {
+    "code": 0,
+    "errorMessage": "string",
+    "result": [
+      {
+        "average": 0,  # 평균 latency (ms)
+        "errorPercent": 0,  # error 비율
+        "label": "string", # 테스트 이름
+        "maxTime": 0,  # 최대 latency  (ms)
+        "median": 0,  # 중간 값 latency (ms)
+        "minTime": 0,   # 최소 latency (ms)
+        "ninetyFive": 0,  # latency 95% 값 (ms)
+        "ninetyNine": 0,  # latency 99% 값 (ms)
+        "ninetyPercent": 0,  # latencyt 90% 값 (ms)
+        "receivedKB": 0,  # 받은 KB / sec
+        "requestCount": 0,  # 발생한 총 요청 count
+        "sentKB": 0,  # 보낸 KB / sec
+        "throughput": 0  # 요청에 대한 처리량 / sec
+      }
+    ],
+    "successMessage": "string"
+  },
+  "[normal]": {
+    "code": 0,
+    "errorMessage": "string",
+    "result": [
+      {
+        "label": "string",
+        "results": [  # 단일 요청에 대한 단일 결과 값들의 목록
+          {
+            "bytes": 0,
+            "connection": 0,
+            "elapsed": 0,  # 개별 요청 총 소요 시간 (ms)
+            "idleTime": 0,
+            "isError": true,  # 에러 여부
+            "latency": 0,  # 개별 요청 지연 시간 (ms)
+            "no": 0,
+            "sentBytes": 0,
+            "timestamp": "string",  # 개별 요청 발생 시간
+            "url": "string"
+          }
+        ]
+      }
+    ],
+    "successMessage": "string"
+  }
+}
+```
+
+#### 성능 평가 지표 조회 응답
+
+```json
+{
+  "code": 0,
+  "errorMessage": "string",
+  "result": [
+    {
+      "label": "string",  # 아래 수집 지표에 대한 목록에서 확인 가능
+      "metrics": [  
+        {
+          "isError": true,  # 해당 요청에 대한 에러 여부
+          "timestamp": "string",  # 개별 요청 발생 시간
+          "unit": "string",  # 아래 수집 지표에 대한 목록에서 확인 가능
+          "value": "string"  # 수집 지표에 대한 값
+        }
+      ]
+    }
+  ],
+  "successMessage": "string"
+}
+```
+
+##### 성능 평가 수집 지표에 대한 목록
+
+```json
+"cpu_all_combined": {  # 전체 cpu 사용률
+        Unit:     "%",
+    },
+    "cpu_all_idle": {  # 유휴 cpu 비율
+        Unit:     "%",
+    },
+    "memory_all_used": {  # 메모리 사용률
+        Unit:     "%",
+    },
+    "memory_all_free": {  # 유휴 메모리 비율
+        Unit:     "%",
+    },
+    "memory_all_used_kb": {  # 메모리 사용 kb
+        Unit:     "mb",
+    },
+    "memory_all_free_kb": {  # 유휴 메모리 kb
+        Unit:     "mb",
+    },
+    "disk_read_kb": {  # 디스크 읽기 kb
+        Unit:     "kb",
+    },
+    "disk_write_kb": {   # 디스크 쓰기 kb
+        Unit:     "kb",
+    },
+    "disk_use": {  # 디스크 사용율
+        Unit:     "%",
+    },
+    "disk_total": {  # 총 디스크 용량 mb
+        Unit:     "mb",
+    },
+    "network_recv_kb": {  # 네트워크 수신 kb
+        Unit:     "kb",
+    },
+    "network_sent_kb": {  # 네트워크 발신 kb
+        Unit:     "kb",
+    },
+```

--- a/docs/load-test-status-api.md
+++ b/docs/load-test-status-api.md
@@ -1,0 +1,101 @@
+# Load test — reading a run's status and steps
+
+A load test runs asynchronously: the request to start one returns immediately with a
+`loadTestKey`, and the run then goes through pre-check, generator install, the load itself and
+result collection on its own. This page describes how a client (the web console, a script)
+reads where a run is, so a screen can show progress and explain a failure without guessing.
+
+## The status endpoint
+
+`GET /api/v1/load/tests/state/last` (operationId `GetLastLoadTestExecutionState`) returns the
+last run for a node. The node is identified by `nsId` / `mciId` / `vmId` in the query.
+
+The result is one `LoadTestExecutionState`:
+
+| Field | Meaning |
+|---|---|
+| `executionStatus` | Where the run is, overall — see below |
+| `startAt` / `finishAt` | When the run started, and finished (finish is null while running) |
+| `expectedFinishAt`, `totalExpectedExecutionSecond` | The expected end, derived from duration + ramp-up. A hint for a progress bar, not a promise — the checks and installs before the load are not counted |
+| `failureMessage` | A one-line reason when the run failed |
+| `nodeUid` | The *uid* of the target node. Node ids are names and get reused, so a caller that keeps showing "the last run for this node" needs the uid to notice the answer belongs to a VM that has since been replaced |
+| `steps` | The per-step progress, as a tree — see [Steps](#steps) |
+
+### executionStatus
+
+| Value | Meaning |
+|---|---|
+| `on_processing` | Running — checks, installs, or the load itself |
+| `on_fetching` | The load has finished and results are being collected |
+| `successed` | Finished; results are available |
+| `test_failed` | Stopped before finishing; `failureMessage` says why |
+
+## Steps
+
+`steps` is the progress of the run as a **tree**: the top level is the *phases* a run goes
+through, and each phase carries its *sub-steps* in `children`. A caller that only wants the
+phases can ignore `children` and read the six phase rows.
+
+Each node — a phase or a sub-step — is one `LoadTestExecutionStepResult`:
+
+| Field | Meaning |
+|---|---|
+| `seq` | Order within the run |
+| `name` | The step identifier. A phase is a bare name (`precheck`); a sub-step is `phase.sub` (`precheck.target_reachable`), the part before the dot naming its phase |
+| `status` | `pending` · `running` · `ok` · `failed` · `skipped` |
+| `attempt` | Retry count (0 = first try) |
+| `startAt` / `finishAt` | When this step started and finished |
+| `message` | A short, current-status line (e.g. `Checking the metric agent port`) |
+| `detail` | The verbose diagnosis or error cause, shown when a step fails (may be multi-line) |
+| `elapsedSec` | How long the step has taken: the whole span once done, or the time so far while running. A phase's figure is rolled up from its children |
+| `children` | The sub-steps of a phase |
+
+`message` moves as the work advances and is the line to show as "what is happening now";
+`detail` is the paragraph to show when something has gone wrong. The phase itself carries a
+static message (`precheck` → "Checking the environment"); the line that actually changes is on
+the running sub-step, so a live status display should read the deepest running node.
+
+### The phases and their sub-steps
+
+All six phases are seeded when the run starts, so the whole outline is visible from the first
+read. Sub-steps appear under the phases that report them; the other phases record at the phase
+level only.
+
+| Phase (`name`) | Sub-steps (`children[].name`) | Notes |
+|---|---|---|
+| `precheck` | `target_exists`, `target_running`, `target_reachable`, `metric_port_open`, `remote_command` | `metric_port_open` only when *Collect Additional System Metrics* is on, else `skipped` |
+| `generator_install` | `reachable` | Sub-step only when reusing a remote generator; a fresh install records at the phase level |
+| `agent_install` | `install`, `process_up`, `port_reachable` | The whole phase runs only when metrics are on, else `skipped` |
+| `jmx_prepare` | — | Phase level only |
+| `jmeter_run` | — | Phase level only. This is the timed load; use `elapsedSec` against `totalExpectedExecutionSecond` for its progress |
+| `result_fetch` | `file_result`, `file_cpu`, `file_memory`, `file_disk`, `file_network` | The metric files only when metrics are on; `file_result` always. See [Result collection](#result-collection) |
+
+A phase with no sub-steps shows its own status only. A run that has not reached a phase leaves
+it `pending`.
+
+## Result collection
+
+Result collection used to be one opaque `result_fetch` step, so a run whose results took far
+longer than the 30-second load gave no clue which file it was waiting on. Each result file is
+now its own sub-step: it starts `running` ("Waiting for the … file"), turns `ok` when it lands
+("… collected"), and turns `skipped` if it never arrives within the wait window. The load
+result failing fails the step; a missing metric file only costs its chart, so it is skipped
+rather than failed. Because the number of files is fixed, a client can show collection as a
+percentage of files received.
+
+The files are pulled with rsync while they are still being written on the generator, so the
+metric files routinely land after the main result — hence the waiting and the retries. What a
+long wait on a file usually means is that the file has not been produced yet, not that the
+transfer is slow.
+
+## Reading the last configuration (Re-run)
+
+`GET /api/v1/load/tests/infos/{loadTestKey}` (operationId `GetLoadTestExecutionInfo`) returns
+the parameters a run was started with — scenario name, virtual users, duration, ramp-up, and
+the HTTP request. A client uses it to pre-fill the form for a re-run.
+
+The configuration is recorded **before** the pre-check runs, so a run that fails in the
+pre-check still has its parameters on record and can be re-run from any client. (Earlier the
+record was written only after pre-check and generator install had both succeeded, so a
+pre-check failure left nothing to read and this call answered 500.) The generator is linked to
+the record after it is installed; until then the record simply has no generator.

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -253,6 +253,46 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		loadTestExecutionState.FinishAt = &finishAt
 	}
 
+	// Persist the requested configuration up front, before anything can fail. A run that dies in
+	// pre-check or generator install used to leave no info row at all, because the save happened
+	// only after both succeeded — so GetLoadTestExecutionInfo (which Re-run reads to pre-fill the
+	// form) had nothing to return and answered 500. The parameters are known from the request, so
+	// record them now; the generator id is not known yet and is linked in after install.
+	var hs []LoadTestExecutionHttpInfo
+	for _, h := range param.HttpReqs {
+		hs = append(hs, LoadTestExecutionHttpInfo{
+			Method:   h.Method,
+			Protocol: h.Protocol,
+			Hostname: h.Hostname,
+			Port:     h.Port,
+			Path:     h.Path,
+			BodyData: h.BodyData,
+		})
+	}
+	loadTestExecutionInfoParam := LoadTestExecutionInfo{
+		LoadTestKey:  param.LoadTestKey,
+		TestName:     param.TestName,
+		VirtualUsers: param.VirtualUsers,
+		Duration:     param.Duration,
+		RampUpTime:   param.RampUpTime,
+		RampUpSteps:  param.RampUpSteps,
+
+		NsId:    param.NsId,
+		InfraId: param.InfraId,
+		NodeId:  param.NodeId,
+
+		AgentInstalled: param.CollectAdditionalSystemMetrics,
+		AgentHostname:  param.AgentHostname,
+
+		LoadTestExecutionHttpInfos: hs,
+		LoadTestExecutionStateId:   loadTestExecutionState.ID,
+	}
+	if err := l.loadRepo.SaveForLoadTestExecutionTx(context.Background(), &loadTestExecutionInfoParam); err != nil {
+		failed(fmt.Sprintf("Error saving load test execution info: %v", err), err)
+		return
+	}
+	loadTestExecutionState.TestExecutionInfoId = loadTestExecutionInfoParam.ID
+
 	// Check the environment before building anything (BAR-1553). A missing target or a closed
 	// port is answered in seconds here, instead of surfacing minutes into a run.
 	precheckCtx, cancelPrecheck := context.WithTimeout(context.Background(), 2*time.Minute)
@@ -311,50 +351,14 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		return
 	}
 
-	var hs []LoadTestExecutionHttpInfo
-
-	for _, h := range param.HttpReqs {
-		hh := LoadTestExecutionHttpInfo{
-			Method:   h.Method,
-			Protocol: h.Protocol,
-			Hostname: h.Hostname,
-			Port:     h.Port,
-			Path:     h.Path,
-			BodyData: h.BodyData,
-		}
-
-		hs = append(hs, hh)
-	}
-
-	loadTestExecutionInfoParam := LoadTestExecutionInfo{
-		LoadTestKey:  param.LoadTestKey,
-		TestName:     param.TestName,
-		VirtualUsers: param.VirtualUsers,
-		Duration:     param.Duration,
-		RampUpTime:   param.RampUpTime,
-		RampUpSteps:  param.RampUpSteps,
-
-		NsId:    param.NsId,
-		InfraId: param.InfraId,
-		NodeId:  param.NodeId,
-
-		AgentInstalled: param.CollectAdditionalSystemMetrics,
-		AgentHostname:  param.AgentHostname,
-
-		LoadGeneratorInstallInfoId: loadGeneratorInstallInfo.ID,
-		LoadTestExecutionHttpInfos: hs,
-
-		LoadTestExecutionStateId: loadTestExecutionState.ID,
-	}
-
-	err = l.loadRepo.SaveForLoadTestExecutionTx(context.Background(), &loadTestExecutionInfoParam)
-	if err != nil {
-		failed(fmt.Sprintf("Error saving load test execution info: %v", err), err)
+	// The generator exists now; link the info row saved earlier to it. TestExecutionInfoId was
+	// already set from the early save above.
+	if err = l.loadRepo.UpdateLoadTestExecutionInfoGeneratorTx(context.Background(), param.LoadTestKey, loadGeneratorInstallInfo.ID); err != nil {
+		failed(fmt.Sprintf("Error linking load test execution info to the generator: %v", err), err)
 		return
 	}
-
+	loadTestExecutionInfoParam.LoadGeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 	loadTestExecutionState.GeneratorInstallInfoId = loadGeneratorInstallInfo.ID
-	loadTestExecutionState.TestExecutionInfoId = loadTestExecutionInfoParam.ID
 
 	err = l.loadRepo.UpdateLoadTestExecutionStateTx(context.Background(), loadTestExecutionState)
 

--- a/internal/core/load/load_test_execution_service.go
+++ b/internal/core/load/load_test_execution_service.go
@@ -357,7 +357,6 @@ func (l *LoadService) processLoadTestAsync(param RunLoadTestParam, loadTestExecu
 		failed(fmt.Sprintf("Error linking load test execution info to the generator: %v", err), err)
 		return
 	}
-	loadTestExecutionInfoParam.LoadGeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 	loadTestExecutionState.GeneratorInstallInfoId = loadGeneratorInstallInfo.ID
 
 	err = l.loadRepo.UpdateLoadTestExecutionStateTx(context.Background(), loadTestExecutionState)

--- a/internal/core/load/models.go
+++ b/internal/core/load/models.go
@@ -152,8 +152,11 @@ type LoadTestExecutionInfo struct {
 	LoadTestExecutionStateId uint
 	LoadTestExecutionState   LoadTestExecutionState
 
-	// LoadTestExecutionInfo has one LoadGeneratorInstallInfo
-	LoadGeneratorInstallInfoId uint
+	// LoadTestExecutionInfo has one LoadGeneratorInstallInfo. Nullable: the config row is now
+	// written before the generator exists (so a run that fails in pre-check still records its
+	// parameters for Re-run), and is linked to the generator once it is installed. A non-null
+	// uint would default to 0 and violate the foreign key on that early insert.
+	LoadGeneratorInstallInfoId *uint
 	LoadGeneratorInstallInfo   LoadGeneratorInstallInfo
 }
 

--- a/internal/core/load/repository.go
+++ b/internal/core/load/repository.go
@@ -351,6 +351,19 @@ func (r *LoadRepository) UpdateLoadTestExecutionInfoDuration(ctx context.Context
 
 }
 
+// UpdateLoadTestExecutionInfoGeneratorTx links the info row to the generator once it is known.
+// The requested configuration is persisted up front, before the generator exists, so a run
+// that fails in pre-check still has its parameters on record; this fills in the generator id
+// afterwards without disturbing the parameters already saved.
+func (r *LoadRepository) UpdateLoadTestExecutionInfoGeneratorTx(ctx context.Context, loadTestKey string, loadGeneratorInstallInfoId uint) error {
+	return r.execInTransaction(ctx, func(d *gorm.DB) error {
+		return d.
+			Model(&LoadTestExecutionInfo{}).
+			Where("load_test_key = ?", loadTestKey).
+			Update("load_generator_install_info_id", loadGeneratorInstallInfoId).Error
+	})
+}
+
 func (r *LoadRepository) GetPagingLoadTestExecutionStateTx(ctx context.Context, param GetAllLoadTestExecutionStateParam) ([]LoadTestExecutionState, int64, error) {
 	var loadTestExecutionStates []LoadTestExecutionState
 	var totalRows int64

--- a/internal/core/load/rsync_fetch_service.go
+++ b/internal/core/load/rsync_fetch_service.go
@@ -107,11 +107,19 @@ func (l *LoadService) fetchData(f *fetchDataParam) {
 // It returns as soon as everything is in. Otherwise it keeps going while progress is being
 // made - each round that brings a new file earns another round - and stops once a whole round
 // adds nothing, or when the overall deadline passes.
+//
+// Each result file is recorded as its own sub-step (BAR: result-fetch granularity), so a
+// collection that sits for a long time shows exactly which file it is still waiting on rather
+// than one opaque "Collecting results". A 30s run whose results take far longer is almost
+// always waiting on a specific metric csv here, and that file is now named as it waits.
 func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 	deadline := time.Now().Add(resultCollectWindow)
 	var outcome fetchOutcome
 	var err error
 	previousMissing := -1
+
+	// Name every file we expect up front so the console draws the whole set from the first poll.
+	f.beginResultFileSteps()
 
 	for round := 1; ; round++ {
 		if f.isRunning() {
@@ -122,8 +130,13 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 		outcome, err = rsyncFiles(f)
 		if err != nil {
 			log.Error().Msgf("error while fetching data from rsync %s", err.Error())
+			f.recordStep(constant.SubFileResult, "failed", "Load result file not collected", err.Error())
 			return outcome, err
 		}
+		// The main file is in (err == nil); flip it and any metric files that have arrived to ok,
+		// and leave the rest waiting with the round they are on.
+		f.recordResultFileProgress(outcome, round)
+
 		if len(outcome.MissingMetrics) == 0 {
 			return outcome, nil
 		}
@@ -133,6 +146,8 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 
 		if !madeProgress || time.Now().After(deadline) {
 			log.Warn().Msgf("giving up on metric files after %d rounds: %v", round, outcome.MissingMetrics)
+			// The load figures are in; the missing metric files only cost their charts.
+			f.skipMissingMetricFiles(outcome)
 			return outcome, nil
 		}
 
@@ -140,6 +155,107 @@ func (l *LoadService) collectResults(f *fetchDataParam) (fetchOutcome, error) {
 			fmt.Sprintf("Collecting results - still waiting for %s", strings.Join(outcome.MissingMetrics, ", ")),
 			"metric files are written during the run and can arrive after the main result")
 		time.Sleep(resultCollectInterval)
+	}
+}
+
+// resultFilePrefixes lists the rsync prefixes this run collects: the main result, plus the
+// metric files when additional system metrics were requested. It matches rsyncFiles exactly.
+func (f *fetchDataParam) resultFilePrefixes() []string {
+	prefixes := []string{""}
+	if f.CollectAdditionalSystemMetrics {
+		prefixes = append(prefixes, "_cpu", "_disk", "_memory", "_network")
+	}
+	return prefixes
+}
+
+// resultFileStep maps an rsync prefix to its sub-step name.
+func resultFileStep(prefix string) constant.ExecutionStep {
+	switch prefix {
+	case "":
+		return constant.SubFileResult
+	case "_cpu":
+		return constant.SubFileCpu
+	case "_disk":
+		return constant.SubFileDisk
+	case "_memory":
+		return constant.SubFileMemory
+	case "_network":
+		return constant.SubFileNetwork
+	}
+	return ""
+}
+
+// resultFileLabel is the human name for a result file, used in the step message.
+func resultFileLabel(prefix string) string {
+	switch prefix {
+	case "":
+		return "load result"
+	case "_cpu":
+		return "cpu metrics"
+	case "_disk":
+		return "disk metrics"
+	case "_memory":
+		return "memory metrics"
+	case "_network":
+		return "network metrics"
+	}
+	return strings.TrimPrefix(prefix, "_")
+}
+
+// recordStep is a nil-safe helper for the file sub-steps.
+func (f *fetchDataParam) recordStep(name constant.ExecutionStep, status, message, detail string) {
+	if f.StepRec == nil || name == "" {
+		return
+	}
+	switch status {
+	case "ok":
+		f.StepRec.ok(name, message)
+	case "failed":
+		f.StepRec.fail(name, message, detail)
+	case "skipped":
+		f.StepRec.skip(name, message)
+	default:
+		f.StepRec.begin(name, message)
+	}
+}
+
+// beginResultFileSteps marks every expected file as waiting, so the set is visible from the start.
+func (f *fetchDataParam) beginResultFileSteps() {
+	for _, p := range f.resultFilePrefixes() {
+		f.recordStep(resultFileStep(p), "running", "Waiting for the "+resultFileLabel(p)+" file", "")
+	}
+}
+
+// recordResultFileProgress flips the files that have arrived to ok and leaves the rest waiting.
+func (f *fetchDataParam) recordResultFileProgress(outcome fetchOutcome, round int) {
+	if f.StepRec == nil {
+		return
+	}
+	missing := map[string]bool{}
+	for _, m := range outcome.MissingMetrics {
+		missing[m] = true
+	}
+	for _, p := range f.resultFilePrefixes() {
+		metric := strings.TrimPrefix(p, "_")
+		if p == "" {
+			f.StepRec.ok(constant.SubFileResult, "Load result file collected")
+			continue
+		}
+		if missing[metric] {
+			f.StepRec.progress(resultFileStep(p), round,
+				fmt.Sprintf("Waiting for the %s file (round %d)", resultFileLabel(p), round),
+				"written on the generator during the run; can arrive after the load result")
+		} else {
+			f.StepRec.ok(resultFileStep(p), resultFileLabel(p)+" collected")
+		}
+	}
+}
+
+// skipMissingMetricFiles records the metric files that never arrived. They are skipped, not
+// failed: the run stands on its load result and only loses those charts (BAR-1552).
+func (f *fetchDataParam) skipMissingMetricFiles(outcome fetchOutcome) {
+	for _, metric := range outcome.MissingMetrics {
+		f.recordStep(resultFileStep("_"+metric), "skipped", resultFileLabel("_"+metric)+" not collected in time", "")
 	}
 }
 


### PR DESCRIPTION
부하테스트 진행 상태를 단계 트리로 보여주는 콘솔 개선에 맞춰, 백엔드에서 두 가지를 보완합니다.

## 변경

**1. 실행 설정 조기 저장 (Re-run 프리필 정확화)**
- 기존에는 실행 설정(`LoadTestExecutionInfo`)을 pre-check·발생기 설치가 모두 성공한 뒤 저장해, pre-check에서 실패한 실행은 설정이 남지 않아 `GetLoadTestExecutionInfo`가 500을 반환하고 Re-run 폼이 비었습니다(특히 다른 브라우저/PC).
- `RunLoadTest`에서 seed 직후(pre-check 전) 설정을 먼저 저장하고, 발생기 설치 후 generator id만 UPDATE 합니다. 발생기 참조(`LoadGeneratorInstallInfoId`)는 nullable(`*uint`)로 바꿔 조기 저장 시 NULL을 허용합니다.

**2. 결과 수집(result_fetch) 파일별 세분화**
- 결과 수집이 단일 단계로만 기록되어, 30초 테스트가 오래 걸릴 때 어느 파일에서 막혔는지 알 수 없었습니다(rsync는 파일이 없어도 계속 재시도).
- 결과 CSV를 파일별 sub-step으로 방출합니다(load result·cpu·memory·disk·network). 대기 → 도착 시 collected → 창 종료까지 미도착 시 skip. 파일 수가 고정이라 수집 진행률을 계산할 수 있습니다.

## 문서
- `docs/load-test-status-api.md` — 상태 조회 API와 `steps[]` 트리 구조(콘솔이 진행 화면을 그릴 때 사용).
- `docs/api-usage-guide.md` — 프로젝트 wiki에 있던 API 사용 가이드를 docs로 이관(상태 섹션 현행화). README 링크를 wiki→docs로 변경.

## 검증
개발 서버에 배포해 실제 부하테스트로 확인.
- 성공 실행 전 구간(pre-check 5·발생기·에이전트 3·테스트 계획·부하 실행·결과 수집 파일별 5) 통과 후 차트 렌더.
- pre-check 실패 실행 후 다른 브라우저에서 Re-run 시 실패 실행의 설정값이 백엔드 조회로 프리필됨.

## 관련
- [BAR-1577](https://mzdevs.atlassian.net/browse/BAR-1577) [cm-ant] 부하테스트 설정 조기 저장·결과 수집 파일별 세분화
- [BAR-1578](https://mzdevs.atlassian.net/browse/BAR-1578) [release][cm-ant] v0.5.7 pre-release 추진

테스트 결과서: `notion/cm-bf-ep-워크로드관리기능개선/003_워크로드검증성능평가기능개선/ST3_단위테스트/TR-BAR-1577-cm-ant-loadtest-backend.md`